### PR TITLE
Fix/update stac v1.0.0

### DIFF
--- a/topo_processor/metadata/metadata_loaders/metadata_loader_imagery_historic.py
+++ b/topo_processor/metadata/metadata_loaders/metadata_loader_imagery_historic.py
@@ -35,6 +35,9 @@ class MetadataLoaderImageryHistoric(MetadataLoader):
         item.add_asset(asset)
         item.collection = collection
 
+        collection.license = "CC BY 4.0"
+        collection.description = "Historical Imagery"
+
         item.properties.update(
             {
                 "linz:sufi": asset_metadata["sufi"],

--- a/topo_processor/metadata/metadata_loaders/metadata_loader_tiff.py
+++ b/topo_processor/metadata/metadata_loaders/metadata_loader_tiff.py
@@ -16,7 +16,7 @@ class MetadataLoaderTiff(MetadataLoader):
         return is_tiff(asset.source_path)
 
     async def load_metadata(self, asset: Asset) -> None:
-        asset.item.add_extension("projection")
+        asset.item.add_extension("https://stac-extensions.github.io/projection/v1.0.0/schema.json")
         fs = get_fs(asset.source_path)
         with fs.open(asset.source_path) as f:
             with rasterio.open(f) as tiff:

--- a/topo_processor/stac/collection.py
+++ b/topo_processor/stac/collection.py
@@ -9,7 +9,7 @@ from linz_logger import get_log
 
 from topo_processor.util import Validity
 
-GLOBAL_PROVIDERS = [pystac.Provider(name="LINZ", description="Land Information New Zealand", roles=["Host"])]
+GLOBAL_PROVIDERS = [pystac.Provider(name="LINZ", description="Land Information New Zealand", roles=["host"])]
 if TYPE_CHECKING:
     from .item import Item
 
@@ -58,9 +58,9 @@ class Collection(Validity):
     def create_stac(self) -> pystac.Collection:
         stac = pystac.Collection(
             id=str(ulid.ULID()),
-            description=None,
-            license=None,
+            description="STAC Collection Metadata for Historical Imagery",
+            license="MIT",
             providers=GLOBAL_PROVIDERS,
-            extent=pystac.SpatialExtent(bboxes=[0, 0, 0, 0]),
+            extent=pystac.Extent(pystac.SpatialExtent(bboxes=[0, 0, 0, 0]), pystac.TemporalExtent(intervals=[None, None])),
         )
         return stac

--- a/topo_processor/stac/collection.py
+++ b/topo_processor/stac/collection.py
@@ -58,8 +58,8 @@ class Collection(Validity):
     def create_stac(self) -> pystac.Collection:
         stac = pystac.Collection(
             id=str(ulid.ULID()),
-            description="STAC Collection Metadata for Historical Imagery",
-            license="MIT",
+            description=self.description,
+            license=self.license,
             providers=GLOBAL_PROVIDERS,
             extent=pystac.Extent(pystac.SpatialExtent(bboxes=[0, 0, 0, 0]), pystac.TemporalExtent(intervals=[None, None])),
         )

--- a/topo_processor/stac/item.py
+++ b/topo_processor/stac/item.py
@@ -24,7 +24,7 @@ class Item(Validity):
         super().__init__()
         self.id = item_id
         self.properties = {}
-        self.stac_extensions = set(["file"])
+        self.stac_extensions = set(["https://stac-extensions.github.io/file/v2.0.0/schema.json"])
         self.collection = None
         self.assets = []
 

--- a/topo_processor/util/transfer_collection.py
+++ b/topo_processor/util/transfer_collection.py
@@ -23,7 +23,10 @@ async def transfer_collection(collection: Collection, target: str):
                 checksum = await asset.get_checksum()
                 transfer_file(asset.source_path, checksum, asset.get_content_type(), os.path.join(target, asset.target))
 
-        write_json(stac_item.to_dict(), os.path.join(target, item.collection.title, f"{item.id}.json"))
+        # 06/07/2021: Workaround for pystac v1.0.0-beta.2
+        json_item = stac_item.to_dict()
+        json_item["stac_version"] = "1.0.0"
+        write_json(json_item, os.path.join(target, item.collection.title, f"{item.id}.json"))
 
     # 06/07/2021: Workaround for pystac v1.0.0-beta.2
     json_collection = stac_collection.to_dict()

--- a/topo_processor/util/transfer_collection.py
+++ b/topo_processor/util/transfer_collection.py
@@ -25,4 +25,9 @@ async def transfer_collection(collection: Collection, target: str):
 
         write_json(stac_item.to_dict(), os.path.join(target, item.collection.title, f"{item.id}.json"))
 
-    write_json(stac_collection.to_dict(), os.path.join(target, collection.title, "collection.json"))
+    # 06/07/2021: Workaround for pystac v1.0.0-beta.2
+    json_collection = stac_collection.to_dict()
+    json_collection["type"] = "Collection"
+    json_collection["stac_version"] = "1.0.0"
+
+    write_json(json_collection, os.path.join(target, collection.title, "collection.json"))


### PR DESCRIPTION
Update stac metadate to validate against STAC v1.0.0
nb: some workarounds as pypi pystac is outdated
nb: some metadata, i.e.- extents, are not completely implemented (they contain placeholder data)