### PR TITLE
fix: use https://spdx.org/licenses/ CC-BY-4.0

### DIFF
--- a/topo_processor/metadata/metadata_loaders/metadata_loader_imagery_historic.py
+++ b/topo_processor/metadata/metadata_loaders/metadata_loader_imagery_historic.py
@@ -35,7 +35,7 @@ class MetadataLoaderImageryHistoric(MetadataLoader):
         item.add_asset(asset)
         item.collection = collection
 
-        collection.license = "CC BY 4.0"
+        collection.license = "CC-BY-4.0"
         collection.description = "Historical Imagery"
 
         item.properties.update(


### PR DESCRIPTION
STAC license metadata must comply with https://spdx.org/licenses/