### PR TITLE
docs: add Alice as a codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @blacha @paulfouquet @MDavidson17
+*   @blacha @paulfouquet @amfage @MDavidson17


### PR DESCRIPTION
To ensure everyone gets automatically tagged in reviews :+1: 