### PR TITLE
fix: circular imports

### DIFF
--- a/topo_processor/data/data_transformers/data_transformer.py
+++ b/topo_processor/data/data_transformers/data_transformer.py
@@ -1,6 +1,10 @@
-from abc import ABC, abstractmethod
+from __future__ import annotations
 
-from topo_processor.stac import Item
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from topo_processor.stac import Item
 
 
 class DataTransformer(ABC):

--- a/topo_processor/data/data_transformers/data_transformer_imagery_historic.py
+++ b/topo_processor/data/data_transformers/data_transformer_imagery_historic.py
@@ -1,14 +1,20 @@
+from __future__ import annotations
+
 import os
+from typing import TYPE_CHECKING
 
 import pystac
 import ulid
 from linz_logger import get_log
 
+import topo_processor.stac as stac
 from topo_processor.cog.create_cog import create_cog
-from topo_processor.stac import Asset, Item
 from topo_processor.util import is_tiff, time_in_ms
 
 from .data_transformer import DataTransformer
+
+if TYPE_CHECKING:
+    from topo_processor.stac import Item
 
 
 class DataTransformerImageryHistoric(DataTransformer):
@@ -34,7 +40,7 @@ class DataTransformerImageryHistoric(DataTransformer):
 
             asset.needs_upload = False
 
-            cog_asset = Asset(output_path)
+            cog_asset = stac.Asset(output_path)
             cog_asset.content_type = pystac.MediaType.COG
             cog_asset.target = asset.target
             cog_asset_list.append(cog_asset)

--- a/topo_processor/data/data_transformers/data_transformer_repo.py
+++ b/topo_processor/data/data_transformers/data_transformer_repo.py
@@ -1,12 +1,16 @@
+from __future__ import annotations
+
 import asyncio
-from typing import List
+from typing import TYPE_CHECKING, List
 
 from linz_logger import get_log
 
-from topo_processor.stac import Item
 from topo_processor.util import time_in_ms
 
 from .data_transformer import DataTransformer
+
+if TYPE_CHECKING:
+    from topo_processor.stac import Item
 
 
 class DataTransformerRepository:

--- a/topo_processor/file_system/tests/get_path_with_protocol_test.py
+++ b/topo_processor/file_system/tests/get_path_with_protocol_test.py
@@ -20,9 +20,7 @@ def test_get_path_with_protocol_local():
     path = "/home/username/dev/topo-processor/test_data/tiffs/SURVEY_1"
     fs = LocalFileSystem(auto_mkdir="True")
     full_path = get_path_with_protocol(source_dir=source_dir_with_forwardslash, source_fs=fs, path=path)
-    print(full_path)
     assert full_path == "/home/username/dev/topo-processor/test_data/tiffs/SURVEY_1"
     source_dir_without_forwardslash = "/home/username/dev/topo-processor/test_data/tiffs"
     full_path = get_path_with_protocol(source_dir=source_dir_without_forwardslash, source_fs=fs, path=path)
-    print(full_path)
     assert full_path == "/home/username/dev/topo-processor/test_data/tiffs/SURVEY_1"

--- a/topo_processor/metadata/metadata_loaders/metadata_loader.py
+++ b/topo_processor/metadata/metadata_loaders/metadata_loader.py
@@ -1,6 +1,10 @@
-from abc import ABC, abstractmethod
+from __future__ import annotations
 
-from topo_processor.stac import Asset
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from topo_processor.stac import Asset
 
 
 class MetadataLoader(ABC):

--- a/topo_processor/metadata/metadata_loaders/metadata_loader_imagery_historic.py
+++ b/topo_processor/metadata/metadata_loaders/metadata_loader_imagery_historic.py
@@ -1,13 +1,17 @@
+from __future__ import annotations
+
 import csv
 import os
-from typing import Dict
+from typing import TYPE_CHECKING, Dict
 
-from topo_processor.stac import Asset, Item
-from topo_processor.stac.stac_extensions import StacExtensions
+import topo_processor.stac as stac
 from topo_processor.stac.store import get_collection, get_item
 from topo_processor.util import convert_value
 
 from .metadata_loader import MetadataLoader
+
+if TYPE_CHECKING:
+    from topo_processor.stac import Asset, Item
 
 
 class MetadataLoaderImageryHistoric(MetadataLoader):
@@ -93,4 +97,4 @@ class MetadataLoaderImageryHistoric(MetadataLoader):
             camera_properties["camera:nominal_focal_length"] = convert_value(asset_metadata["nominal_focal_length"])
         if len(camera_properties) > 0:
             item.properties.update(camera_properties)
-            item.add_extension(StacExtensions.camera.value)
+            item.add_extension(stac.StacExtensions.camera.value)

--- a/topo_processor/metadata/metadata_loaders/metadata_loader_repo.py
+++ b/topo_processor/metadata/metadata_loaders/metadata_loader_repo.py
@@ -1,12 +1,16 @@
+from __future__ import annotations
+
 import asyncio
-from typing import List
+from typing import TYPE_CHECKING, List
 
 from linz_logger import get_log
 
-from topo_processor.stac import Asset
 from topo_processor.util import time_in_ms
 
 from .metadata_loader import MetadataLoader
+
+if TYPE_CHECKING:
+    from topo_processor.stac import Asset
 
 
 class MetadataLoaderRepository:

--- a/topo_processor/metadata/metadata_loaders/metadata_loader_tiff.py
+++ b/topo_processor/metadata/metadata_loaders/metadata_loader_tiff.py
@@ -1,11 +1,17 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import rasterio
 
+import topo_processor.stac as stac
 from topo_processor.file_system.get_fs import get_fs
-from topo_processor.stac import Asset
-from topo_processor.stac.stac_extensions import StacExtensions
 from topo_processor.util import is_tiff
 
 from .metadata_loader import MetadataLoader
+
+if TYPE_CHECKING:
+    from topo_processor.stac import Asset
 
 
 class MetadataLoaderTiff(MetadataLoader):
@@ -17,7 +23,7 @@ class MetadataLoaderTiff(MetadataLoader):
         return is_tiff(asset.source_path)
 
     async def load_metadata(self, asset: Asset) -> None:
-        asset.item.add_extension(StacExtensions.projection.value)
+        asset.item.add_extension(stac.StacExtensions.projection.value)
         fs = get_fs(asset.source_path)
         with fs.open(asset.source_path) as f:
             with rasterio.open(f) as tiff:

--- a/topo_processor/metadata/metadata_validators/metadata_validator.py
+++ b/topo_processor/metadata/metadata_validators/metadata_validator.py
@@ -1,6 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from abc import ABC, abstractmethod
 
-from topo_processor.stac import Item
+if TYPE_CHECKING:
+    from topo_processor.stac import Item
 
 
 class MetadataValidator(ABC):

--- a/topo_processor/metadata/metadata_validators/metadata_validator.py
+++ b/topo_processor/metadata/metadata_validators/metadata_validator.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from topo_processor.stac import Item

--- a/topo_processor/metadata/metadata_validators/metadata_validator_imagery_historic.py
+++ b/topo_processor/metadata/metadata_validators/metadata_validator_imagery_historic.py
@@ -1,10 +1,14 @@
+from __future__ import annotations
+
 import os
+from typing import TYPE_CHECKING
 
 from linz_logger import get_log
 
-from topo_processor.stac import Item
-
 from .metadata_validator import MetadataValidator
+
+if TYPE_CHECKING:
+    from topo_processor.stac import Item
 
 
 class MetadataValidatorImageryHistoric(MetadataValidator):

--- a/topo_processor/metadata/metadata_validators/metadata_validator_repo.py
+++ b/topo_processor/metadata/metadata_validators/metadata_validator_repo.py
@@ -1,12 +1,16 @@
+from __future__ import annotations
+
 import asyncio
-from typing import List
+from typing import TYPE_CHECKING, List
 
 from linz_logger import get_log
 
-from topo_processor.stac import Item
 from topo_processor.util import time_in_ms
 
 from .metadata_validator import MetadataValidator
+
+if TYPE_CHECKING:
+    from topo_processor.stac import Item
 
 
 class MetadataValidatorRepository:

--- a/topo_processor/metadata/metadata_validators/metadata_validator_stac.py
+++ b/topo_processor/metadata/metadata_validators/metadata_validator_stac.py
@@ -1,8 +1,13 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from pystac.errors import STACValidationError
 
-from topo_processor.stac import Item
-
 from .metadata_validator import MetadataValidator
+
+if TYPE_CHECKING:
+    from topo_processor.stac import Item
 
 
 class MetadataValidatorStac(MetadataValidator):

--- a/topo_processor/metadata/metadata_validators/metadata_validator_tiff.py
+++ b/topo_processor/metadata/metadata_validators/metadata_validator_tiff.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import rasterio
 from rasterio.enums import ColorInterp
 
-from topo_processor.stac import Item
 from topo_processor.util import is_tiff
 
 from .metadata_validator import MetadataValidator
+
+if TYPE_CHECKING:
+    from topo_processor.stac import Item
 
 
 class MetadataValidatorTiff(MetadataValidator):

--- a/topo_processor/metadata/metadata_validators/tests/metadata_validator_stac_test.py
+++ b/topo_processor/metadata/metadata_validators/tests/metadata_validator_stac_test.py
@@ -3,21 +3,20 @@ import os
 import pytest
 from pystac.errors import STACValidationError
 
+import topo_processor.stac as stac
 from topo_processor.metadata.metadata_validators.metadata_validator_stac import MetadataValidatorStac
-from topo_processor.stac import Asset, Item
-from topo_processor.stac.stac_extensions import StacExtensions
 
 
 @pytest.mark.asyncio
 async def test_check_validity():
     """check fails due to string"""
     source_path = os.path.join(os.getcwd(), "test_data", "tiffs", "SURVEY_1", "CONTROL.tiff")
-    asset = Asset(source_path)
-    item = Item("item_id")
+    asset = stac.Asset(source_path)
+    item = stac.Item("item_id")
     item.add_asset(asset)
     item.properties.update({"camera:nominal_focal_length": "string"})
     item.properties.update({"camera:sequence_number": 1234})
-    item.add_extension(StacExtensions.camera.value)
+    item.add_extension(stac.StacExtensions.camera.value)
 
     validator = MetadataValidatorStac()
     assert validator.is_applicable(item)

--- a/topo_processor/stac/collection.py
+++ b/topo_processor/stac/collection.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 import os
 from shutil import rmtree
@@ -29,7 +31,7 @@ class Collection(Validity):
         self.title = title
         self.items = {}
 
-    def add_item(self, item: "Item"):
+    def add_item(self, item: Item):
         if item.collection is not None and item.collection != self:
             raise Exception(f"Remapping of collection? existing='{item.collection.title}' new='{self.title}' item='{item.id}'")
         if item.id in self.items:

--- a/topo_processor/stac/item.py
+++ b/topo_processor/stac/item.py
@@ -3,11 +3,11 @@ from typing import List
 
 import pystac
 
-from topo_processor.stac.stac_extensions import StacExtensions
 from topo_processor.util import Validity
 
 from .asset import Asset
 from .collection import Collection
+from .stac_extensions import StacExtensions
 
 
 class Item(Validity):

--- a/topo_processor/stac/item_factory.py
+++ b/topo_processor/stac/item_factory.py
@@ -1,10 +1,9 @@
 import asyncio
-import os
 
 from linz_logger import get_log
 
 from topo_processor.data.data_transformers import data_transformer_repo
-from topo_processor.file_system.get_fs import get_fs, is_s3_path
+from topo_processor.file_system.get_fs import get_fs
 from topo_processor.file_system.get_path_with_protocol import get_path_with_protocol
 from topo_processor.metadata.metadata_loaders import metadata_loader_repo
 from topo_processor.metadata.metadata_validators import metadata_validator_repo

--- a/topo_processor/util/transfer_collection.py
+++ b/topo_processor/util/transfer_collection.py
@@ -1,11 +1,16 @@
+from __future__ import annotations
+
 import os
+from typing import TYPE_CHECKING
 
 from linz_logger import get_log
 from pystac.catalog import CatalogType
 
 from topo_processor.file_system.transfer import transfer_file
 from topo_processor.file_system.write_json import write_json
-from topo_processor.stac import Collection
+
+if TYPE_CHECKING:
+    from topo_processor.stac import Collection
 
 
 async def transfer_collection(collection: Collection, target: str):


### PR DESCRIPTION
Changed import statements and used [typing.TYPE_CHECKING](https://docs.python.org/3/library/typing.html#typing.TYPE_CHECKING) to resolve circular import errors. 

**note:** [(VIDEO) A good explaination of the circular import error and resolution](https://www.youtube.com/watch?v=B5cjckVzY4g&t=315s&ab_channel=anthonywritescode)