### PR TITLE
feat: set temporal extent (TDE-148)

### DIFF
--- a/topo_processor/metadata/metadata_loaders/metadata_loader_imagery_historic.py
+++ b/topo_processor/metadata/metadata_loaders/metadata_loader_imagery_historic.py
@@ -7,7 +7,13 @@ from topo_processor import metadata
 
 import topo_processor.stac as stac
 from topo_processor.stac.store import get_collection, get_item
-from topo_processor.util import quarterdate_to_datetime, remove_empty_strings, string_to_boolean, string_to_number, nzt_datetime_to_utc_datetime
+from topo_processor.util import (
+    quarterdate_to_datetime,
+    remove_empty_strings,
+    string_to_boolean,
+    string_to_number,
+    nzt_datetime_to_utc_datetime,
+)
 
 from .metadata_loader import MetadataLoader
 
@@ -165,6 +171,9 @@ class MetadataLoaderImageryHistoric(MetadataLoader):
         item_date = asset_metadata.get("date", None)
 
         if item_date:
-            item.datetime = nzt_datetime_to_utc_datetime(item_date)
+            try:
+                item.datetime = nzt_datetime_to_utc_datetime(item_date)
+            except Exception as e:
+                item.add_error(msg="Invalid date", cause=self.name, e=e)
         else:
-            item.datetime = None
+            item.add_error(msg="No date found", cause=self.name, e=Exception(f"item date has no value"))

--- a/topo_processor/metadata/metadata_loaders/metadata_loader_imagery_historic.py
+++ b/topo_processor/metadata/metadata_loaders/metadata_loader_imagery_historic.py
@@ -3,16 +3,16 @@ from __future__ import annotations
 import csv
 import os
 from typing import TYPE_CHECKING, Dict
-from topo_processor import metadata
 
 import topo_processor.stac as stac
+from topo_processor import metadata
 from topo_processor.stac.store import get_collection, get_item
 from topo_processor.util import (
+    nzt_datetime_to_utc_datetime,
     quarterdate_to_datetime,
     remove_empty_strings,
     string_to_boolean,
     string_to_number,
-    nzt_datetime_to_utc_datetime,
 )
 
 from .metadata_loader import MetadataLoader

--- a/topo_processor/metadata/metadata_loaders/tests/metadata_loader_imagery_historic_test.py
+++ b/topo_processor/metadata/metadata_loaders/tests/metadata_loader_imagery_historic_test.py
@@ -143,3 +143,28 @@ def test_scanning_metadata_added():
     assert stac.StacExtensions.scanning.value in item.stac_extensions
     assert item.properties["scan:is_original"]
     assert "scan:scanned" not in item.properties.keys()
+
+def test_add_datetime_property():
+    source_path = "test_abc.tiff"
+    item = stac.Item(source_path)
+    metadata = {"date": "1952-04-23T00:00:00.000"}
+    metadata_loader_imagery_historic = MetadataLoaderImageryHistoric()
+    metadata_loader_imagery_historic.add_datetime_property(item, asset_metadata=metadata)
+    assert item.datetime is not None
+    assert item.datetime.isoformat() == "1952-04-22T12:00:00+00:00"
+
+def test_add_datetime_property_empty():
+    source_path = "test_abc.tiff"
+    item = stac.Item(source_path)
+    metadata = {"date": ""}
+    metadata_loader_imagery_historic = MetadataLoaderImageryHistoric()
+    metadata_loader_imagery_historic.add_datetime_property(item, asset_metadata=metadata)
+    assert item.datetime is None
+
+def test_add_datetime_property_not_date():
+    source_path = "test_abc.tiff"
+    item = stac.Item(source_path)
+    metadata = {"date": "toto"}
+    metadata_loader_imagery_historic = MetadataLoaderImageryHistoric()
+    metadata_loader_imagery_historic.add_datetime_property(item, asset_metadata=metadata)
+    assert item.datetime is None

--- a/topo_processor/metadata/metadata_loaders/tests/metadata_loader_imagery_historic_test.py
+++ b/topo_processor/metadata/metadata_loaders/tests/metadata_loader_imagery_historic_test.py
@@ -144,6 +144,7 @@ def test_scanning_metadata_added():
     assert item.properties["scan:is_original"]
     assert "scan:scanned" not in item.properties.keys()
 
+
 def test_add_datetime_property():
     source_path = "test_abc.tiff"
     item = stac.Item(source_path)
@@ -153,6 +154,7 @@ def test_add_datetime_property():
     assert item.datetime is not None
     assert item.datetime.isoformat() == "1952-04-22T12:00:00+00:00"
 
+
 def test_add_datetime_property_empty():
     source_path = "test_abc.tiff"
     item = stac.Item(source_path)
@@ -160,6 +162,7 @@ def test_add_datetime_property_empty():
     metadata_loader_imagery_historic = MetadataLoaderImageryHistoric()
     metadata_loader_imagery_historic.add_datetime_property(item, asset_metadata=metadata)
     assert item.datetime is None
+
 
 def test_add_datetime_property_not_date():
     source_path = "test_abc.tiff"

--- a/topo_processor/metadata/metadata_loaders/tests/metadata_loader_imagery_historic_test.py
+++ b/topo_processor/metadata/metadata_loaders/tests/metadata_loader_imagery_historic_test.py
@@ -172,7 +172,7 @@ def test_add_datetime_property_not_date():
     metadata_loader_imagery_historic.add_datetime_property(item, asset_metadata=metadata)
     assert item.datetime is None
 
-    
+
 def test_spatial_metadata_empty():
     source_path = "test_abc.tiff"
     item = stac.Item(source_path)

--- a/topo_processor/metadata/metadata_validators/tests/metadata_validator_stac_test.py
+++ b/topo_processor/metadata/metadata_validators/tests/metadata_validator_stac_test.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import os
 from typing import Dict
 
@@ -13,6 +14,7 @@ def test_check_validity_camera_extension():
     source_path = os.path.join(os.getcwd(), "test_data", "tiffs", "SURVEY_1", "CONTROL.tiff")
     asset = stac.Asset(source_path)
     item = stac.Item("item_id")
+    item.datetime = datetime.now()
     item.add_asset(asset)
     item.properties.update({"camera:nominal_focal_length": "string"})
     item.properties.update({"camera:sequence_number": 1234})
@@ -39,6 +41,7 @@ def test_check_validity_fails_on_string_aerial_photo_extension():
     source_path = os.path.join(os.getcwd(), "test_data", "tiffs", "SURVEY_1", "CONTROL.tiff")
     asset = stac.Asset(source_path)
     item = stac.Item("item_id")
+    item.datetime = datetime.now()
     item.add_asset(asset)
     item.properties.update({"aerial-photo:run": "string"})
     item.properties.update({"aerial-photo:altitude": "string"})
@@ -57,6 +60,7 @@ def test_check_validity_fails_on_required_field_aerial_photo_extension():
     source_path = os.path.join(os.getcwd(), "test_data", "tiffs", "SURVEY_1", "CONTROL.tiff")
     asset = stac.Asset(source_path)
     item = stac.Item("item_id")
+    item.datetime = datetime.now()
     item.add_asset(asset)
     item.properties.update({"aerial-photo:altitude": 1234})
     item.properties.update({"aerial-photo:scale": 1234})
@@ -74,6 +78,7 @@ def test_check_validity_scanning_extension():
     source_path = os.path.join(os.getcwd(), "test_data", "tiffs", "SURVEY_1", "CONTROL.tiff")
     asset = stac.Asset(source_path)
     item = stac.Item("item_id")
+    item.datetime = datetime.now()
     item.add_asset(asset)
     item.properties.update({"scan:is_original": True})
     item.properties.update({"scan:scanned": "string"})
@@ -90,6 +95,7 @@ def test_validate_metadata_with_report():
     source_path = os.path.join(os.getcwd(), "test_data", "tiffs", "SURVEY_1", "CONTROL.tiff")
     asset = stac.Asset(source_path)
     item = stac.Item("item_id")
+    item.datetime = datetime.now()
     item.add_asset(asset)
     item.properties.update({"film:id": "1234"})
     item.properties.update({"film:negative_sequence": "string"})

--- a/topo_processor/metadata/metadata_validators/tests/metadata_validator_stac_test.py
+++ b/topo_processor/metadata/metadata_validators/tests/metadata_validator_stac_test.py
@@ -1,5 +1,5 @@
-from datetime import datetime
 import os
+from datetime import datetime
 from typing import Dict
 
 import pytest

--- a/topo_processor/stac/collection.py
+++ b/topo_processor/stac/collection.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
+from datetime import datetime
 
-import datetime
 import os
 from shutil import rmtree
 from tempfile import mkdtemp
@@ -51,6 +51,18 @@ class Collection(Validity):
             os.mkdir(temp_dir)
         return temp_dir
 
+    def get_temporal_extent(self) -> List[datetime | None]:
+        intervals: List[datetime | None] = [None, None]
+        datetimes = []
+
+        for item in self.items.values():
+            datetimes.append(item.datetime)
+        
+        if datetimes:
+            intervals = [min(datetimes), max(datetimes)]
+        
+        return intervals
+
     def delete_temp_dir(self):
         global TEMP_DIR
         if TEMP_DIR:
@@ -67,7 +79,7 @@ class Collection(Validity):
             providers=GLOBAL_PROVIDERS,
             extent=pystac.Extent(
                 pystac.SpatialExtent(bboxes=[[0, 0, 0, 0]]),
-                pystac.TemporalExtent(intervals=[datetime.datetime.now(), datetime.datetime.now()]),
+                pystac.TemporalExtent(intervals=[self.get_temporal_extent()]),
             ),
         )
         return stac

--- a/topo_processor/stac/collection.py
+++ b/topo_processor/stac/collection.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
-from datetime import datetime
 
 import os
+from datetime import datetime
 from shutil import rmtree
 from tempfile import mkdtemp
 from typing import TYPE_CHECKING, Dict, List

--- a/topo_processor/stac/collection.py
+++ b/topo_processor/stac/collection.py
@@ -53,17 +53,22 @@ class Collection(Validity):
         return temp_dir
 
     def get_temporal_extent(self) -> List[datetime | None]:
-        intervals: List[datetime | None] = [None, None]
-        datetimes = []
+        min_date = None
+        max_date = None
 
         for item in self.items.values():
             if item.datetime:
-                datetimes.append(item.datetime)
+                if not min_date:
+                    min_date = item.datetime
+                elif item.datetime < min_date:
+                    min_date = item.datetime
 
-        if datetimes:
-            intervals = [min(datetimes), max(datetimes)]
+                if not max_date:
+                    max_date = item.datetime
+                elif item.datetime > max_date:
+                    max_date = item.datetime
 
-        return intervals
+        return [min_date, max_date]
 
     def get_bounding_boxes(self):
         """

--- a/topo_processor/stac/collection.py
+++ b/topo_processor/stac/collection.py
@@ -56,11 +56,12 @@ class Collection(Validity):
         datetimes = []
 
         for item in self.items.values():
-            datetimes.append(item.datetime)
-        
+            if item.datetime:
+                datetimes.append(item.datetime)
+
         if datetimes:
             intervals = [min(datetimes), max(datetimes)]
-        
+
         return intervals
 
     def delete_temp_dir(self):

--- a/topo_processor/stac/item.py
+++ b/topo_processor/stac/item.py
@@ -24,7 +24,7 @@ class Item(Validity):
     def __init__(self, item_id: str):
         super().__init__()
         self.id = item_id
-        self.datetime = datetime.datetime.now()
+        self.datetime = None
         self.properties = {}
         self.stac_extensions = set([StacExtensions.file.value])
         self.collection = None

--- a/topo_processor/stac/item.py
+++ b/topo_processor/stac/item.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+import datetime
 from typing import List
 
 import pystac
@@ -15,7 +15,7 @@ class Item(Validity):
     id: str
     geometry: str
     bbox: str
-    datetime: datetime
+    datetime: datetime.datetime
     properties: dict
     stac_extensions: set
     collection: Collection
@@ -24,6 +24,7 @@ class Item(Validity):
     def __init__(self, item_id: str):
         super().__init__()
         self.id = item_id
+        self.datetime = datetime.datetime.now()
         self.properties = {}
         self.stac_extensions = set([StacExtensions.file.value])
         self.collection = None
@@ -51,7 +52,7 @@ class Item(Validity):
             id=self.id,
             geometry=None,
             bbox=None,
-            datetime=datetime.now(),
+            datetime=self.datetime,
             properties=self.properties,
             stac_extensions=list(self.stac_extensions),
         )

--- a/topo_processor/stac/item.py
+++ b/topo_processor/stac/item.py
@@ -57,9 +57,6 @@ class Item(Validity):
 
         stac = pystac.Item(
             id=self.id,
-            geometry=None,
-            bbox=None,
-            datetime=self.datetime,
             geometry=geometry,
             bbox=bbox,
             datetime=self.datetime,

--- a/topo_processor/stac/item_factory.py
+++ b/topo_processor/stac/item_factory.py
@@ -31,7 +31,7 @@ def process_metadata(metadata_file: str) -> None:
 
     # Validate item against schema
     for item in item_store.values():
-        if item.is_valid():
+        if item.is_valid():  # type: ignore[no-untyped-call]
             errors_per_item[item.id] = metadata_validator_stac.validate_metadata_with_report(item)
             total_items_processed = total_items_processed + 1
 

--- a/topo_processor/stac/item_factory.py
+++ b/topo_processor/stac/item_factory.py
@@ -31,7 +31,7 @@ def process_metadata(metadata_file: str) -> None:
 
     # Validate item against schema
     for item in item_store.values():
-        if item.is_valid():  # type: ignore[no-untyped-call]
+        if item.is_valid():
             errors_per_item[item.id] = metadata_validator_stac.validate_metadata_with_report(item)
             total_items_processed = total_items_processed + 1
 

--- a/topo_processor/stac/tests/collection_test.py
+++ b/topo_processor/stac/tests/collection_test.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import pytest
 import shapely.wkt
 
@@ -51,3 +53,32 @@ def test_polygon_union():
     collection.add_item(item_b)
     item_b.geometry_poly = shapely.wkt.loads("POLYGON ((5 6,5 8,7 8,7 6,5 6))")
     assert collection.get_bounding_boxes() == [(1.0, 2.0, 7.0, 8.0)]
+
+
+def test_get_temporal_extent():
+    collection = Collection("fake_collection")
+    datetime_earliest = datetime.strptime("1918-11-11", "%Y-%m-%d")
+    datetime_mid = datetime.strptime("1945-05-08", "%Y-%m-%d")
+    datetime_latest = datetime.strptime("1989-11-09", "%Y-%m-%d")
+
+    item_x = Item("id_0")
+    item_x.datetime = None
+    collection.add_item(item_x)
+
+    item_a = Item("id_1")
+    item_a.datetime = datetime_latest
+    collection.add_item(item_a)
+
+    item_b = Item("id_2")
+    item_b.datetime = datetime_earliest
+    collection.add_item(item_b)
+
+    item_c = Item("id_3")
+    item_c.datetime = None
+    collection.add_item(item_c)
+
+    item_d = Item("id_4")
+    item_d.datetime = datetime_mid
+    collection.add_item(item_d)
+
+    assert collection.get_temporal_extent() == [datetime_earliest, datetime_latest]

--- a/topo_processor/util/__init__.py
+++ b/topo_processor/util/__init__.py
@@ -1,5 +1,11 @@
 from .checksum import multihash_as_hex
-from .conversions import quarterdate_to_datetime, remove_empty_strings, string_to_boolean, string_to_number, nzt_datetime_to_utc_datetime
+from .conversions import (
+    quarterdate_to_datetime,
+    remove_empty_strings,
+    string_to_boolean,
+    string_to_number,
+    nzt_datetime_to_utc_datetime,
+)
 from .tiff import is_tiff
 from .time import time_in_ms
 from .valid import Validity

--- a/topo_processor/util/__init__.py
+++ b/topo_processor/util/__init__.py
@@ -1,10 +1,10 @@
 from .checksum import multihash_as_hex
 from .conversions import (
+    nzt_datetime_to_utc_datetime,
     quarterdate_to_datetime,
     remove_empty_strings,
     string_to_boolean,
     string_to_number,
-    nzt_datetime_to_utc_datetime,
 )
 from .tiff import is_tiff
 from .time import time_in_ms

--- a/topo_processor/util/__init__.py
+++ b/topo_processor/util/__init__.py
@@ -1,5 +1,5 @@
 from .checksum import multihash_as_hex
-from .conversions import quarterdate_to_datetime, remove_empty_strings, string_to_boolean, string_to_number
+from .conversions import quarterdate_to_datetime, remove_empty_strings, string_to_boolean, string_to_number, nzt_datetime_to_utc_datetime
 from .tiff import is_tiff
 from .time import time_in_ms
 from .valid import Validity

--- a/topo_processor/util/conversions.py
+++ b/topo_processor/util/conversions.py
@@ -57,11 +57,16 @@ def quarterdate_to_datetime(value):
 
     return value
 
-def nzt_datetime_to_utc_datetime(date: str) -> datetime:
-    utc_tz = tz.gettz('UTC')
-    nz_tz = tz.gettz('Pacific/Auckland')
 
-    nz_time = parser.parse(date).replace(tzinfo=nz_tz)
+def nzt_datetime_to_utc_datetime(date: str) -> datetime:
+    utc_tz = tz.gettz("UTC")
+    nz_tz = tz.gettz("Pacific/Auckland")
+
+    try:
+        nz_time = parser.parse(date).replace(tzinfo=nz_tz)
+    except parser.ParserError as err:
+        raise Exception(f"Not a valid date: {err}") from err
+
     utc_time = nz_time.astimezone(utc_tz)
 
     return utc_time

--- a/topo_processor/util/conversions.py
+++ b/topo_processor/util/conversions.py
@@ -1,6 +1,7 @@
-from datetime import datetime
 import re
+from datetime import datetime
 from typing import Dict
+
 from dateutil import parser, tz
 
 

--- a/topo_processor/util/conversions.py
+++ b/topo_processor/util/conversions.py
@@ -1,5 +1,7 @@
+from datetime import datetime
 import re
 from typing import Dict
+from dateutil import parser, tz
 
 
 def string_to_number(value):
@@ -54,3 +56,12 @@ def quarterdate_to_datetime(value):
         return rfc3339_value
 
     return value
+
+def nzt_datetime_to_utc_datetime(date: str) -> datetime:
+    utc_tz = tz.gettz('UTC')
+    nz_tz = tz.gettz('Pacific/Auckland')
+
+    nz_time = parser.parse(date).replace(tzinfo=nz_tz)
+    utc_time = nz_time.astimezone(utc_tz)
+
+    return utc_time

--- a/topo_processor/util/tests/conversions_test.py
+++ b/topo_processor/util/tests/conversions_test.py
@@ -1,0 +1,7 @@
+import pytest
+
+from topo_processor.util import nzt_datetime_to_utc_datetime
+
+def test_nzt_datetime_to_utc_datetime():
+    utc_date = nzt_datetime_to_utc_datetime('1988-01-11T00:00:00.000')
+    assert utc_date.isoformat() == '1988-01-10T11:00:00+00:00'

--- a/topo_processor/util/tests/conversions_test.py
+++ b/topo_processor/util/tests/conversions_test.py
@@ -3,6 +3,11 @@ import pytest
 from topo_processor.util import nzt_datetime_to_utc_datetime
 
 
-def test_nzt_datetime_to_utc_datetime():
+def test_nzt_datetime_to_utc_datetime_daylight_saving_on():
     utc_date = nzt_datetime_to_utc_datetime("1988-01-11T00:00:00.000")
     assert utc_date.isoformat() == "1988-01-10T11:00:00+00:00"
+
+
+def test_nzt_datetime_to_utc_datetime_daylight_saving_off():
+    utc_date = nzt_datetime_to_utc_datetime("1988-07-11T00:00:00.000")
+    assert utc_date.isoformat() == "1988-07-10T12:00:00+00:00"

--- a/topo_processor/util/tests/conversions_test.py
+++ b/topo_processor/util/tests/conversions_test.py
@@ -2,6 +2,7 @@ import pytest
 
 from topo_processor.util import nzt_datetime_to_utc_datetime
 
+
 def test_nzt_datetime_to_utc_datetime():
-    utc_date = nzt_datetime_to_utc_datetime('1988-01-11T00:00:00.000')
-    assert utc_date.isoformat() == '1988-01-10T11:00:00+00:00'
+    utc_date = nzt_datetime_to_utc_datetime("1988-01-11T00:00:00.000")
+    assert utc_date.isoformat() == "1988-01-10T11:00:00+00:00"

--- a/topo_processor/util/tests/transfer_collection_test.py
+++ b/topo_processor/util/tests/transfer_collection_test.py
@@ -1,8 +1,8 @@
-from datetime import date, datetime
 import shutil
+from datetime import date, datetime
 from tempfile import mkdtemp
-import dateutil
 
+import dateutil
 import pytest
 
 from topo_processor.stac import Asset, Collection, Item

--- a/topo_processor/util/tests/transfer_collection_test.py
+++ b/topo_processor/util/tests/transfer_collection_test.py
@@ -1,5 +1,7 @@
+from datetime import date, datetime
 import shutil
 from tempfile import mkdtemp
+import dateutil
 
 import pytest
 

--- a/topo_processor/util/tests/transfer_collection_test.py
+++ b/topo_processor/util/tests/transfer_collection_test.py
@@ -27,6 +27,7 @@ def test_fail_on_duplicate_assets(setup):
     collection.description = "fake_description"
     collection.license = "face_license"
     item = Item("item_id")
+    item.datetime = datetime.now()
     collection.add_item(item)
     item.collection = collection
 

--- a/topo_processor/util/transfer_collection.py
+++ b/topo_processor/util/transfer_collection.py
@@ -21,14 +21,13 @@ def transfer_collection(collection: Collection, target: str):
     stac_collection.catalog_type = CatalogType.SELF_CONTAINED
 
     for item in collection.items.values():
-        stac_item = item.create_stac()
-
         if not item.is_valid():
             get_log().warning("Invalid item was not uploaded:", error=item.log)
             continue
         if item.log:
             get_log().warning(f"Item {item.id} contains warnings:", error=item.log)
 
+        stac_item = item.create_stac()
         stac_collection.add_item(stac_item)
         # pystac v1.1.0
         # Required to change the pystac default of ./{id}/{id}.json


### PR DESCRIPTION
### Change Description:
Set the `item.datetime` required property and the `Temporal Extent` for the `Collection`

### Notes for Testing:
As the `item.datetime` is a required property for STAC, the item should not be valid/added if this data is missing or invalid in the metadata.

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence updated (where applicable)

#### Testing Tasks:
- [x] Added tests that fail without this change
- [x] All tests are passing in development environment
- [ ] Reviewers assigned
- [ ] Linked to main issue for ZenHub board
