### PR TITLE
fix: bytes need to be decoded first

### DIFF
--- a/topo_processor/metadata/metadata_validators/metadata_validator_stac.py
+++ b/topo_processor/metadata/metadata_validators/metadata_validator_stac.py
@@ -22,7 +22,7 @@ class MetadataValidatorStac(MetadataValidator):
         if schema_uri not in self.validator_cache:
             response = urllib.request.urlopen(schema_uri)
             schema = response.read()
-            self.validator_cache[schema_uri] = jsonschema_rs.JSONSchema.from_str(schema.decode('utf8'))
+            self.validator_cache[schema_uri] = jsonschema_rs.JSONSchema.from_str(schema.decode("utf8"))
 
         validator = self.validator_cache[schema_uri]
 

--- a/topo_processor/metadata/metadata_validators/metadata_validator_stac.py
+++ b/topo_processor/metadata/metadata_validators/metadata_validator_stac.py
@@ -22,7 +22,7 @@ class MetadataValidatorStac(MetadataValidator):
         if schema_uri not in self.validator_cache:
             response = urllib.request.urlopen(schema_uri)
             schema = response.read()
-            self.validator_cache[schema_uri] = jsonschema_rs.JSONSchema.from_str(schema)
+            self.validator_cache[schema_uri] = jsonschema_rs.JSONSchema.from_str(schema.decode('utf8'))
 
         validator = self.validator_cache[schema_uri]
 


### PR DESCRIPTION
urlib gives us `bytes` not a `str`, so it needs to be decoded.

We can maybe always assume it is a `utf-8` encoding these days.