### PR TITLE
perf: json loads/dumps is no longer needed as tuples are handled by jsonschema_rs

### DIFF
--- a/topo_processor/metadata/metadata_validators/metadata_validator_stac.py
+++ b/topo_processor/metadata/metadata_validators/metadata_validator_stac.py
@@ -41,8 +41,6 @@ class MetadataValidatorStac(MetadataValidator):
     def validate_metadata_with_report(self, item: Item) -> Dict[str, list[str]]:
         errors_report: Dict[str, list[str]] = {}
         stac_item = item.create_stac().to_dict(include_self_link=False)
-        # get `json.dumps` to convert `tuple` into `array` to allow `jsonschema-rs` to validate
-        stac_item = json.loads(json.dumps(stac_item))
         schema_uris: list[str] = [item.schema] + stac_item["stac_extensions"]
 
         get_log().debug(f"{self.name}:validate_metadata_with_report", itemId=stac_item["id"])


### PR DESCRIPTION
Fixes: #  
_Add new line for each issue that was fixed_

### Change Description:

...

### Notes for Testing:

...

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned
- [ ] Linked to main issue for ZenHub board
