### PR TITLE
fix: asset object key TDE-188

### DIFF
--- a/topo_processor/cli/tests/main_test.py
+++ b/topo_processor/cli/tests/main_test.py
@@ -51,10 +51,10 @@ def test_upload_local(setup):
     assert item_metadata["properties"]["linz:sufi"] == "72352"
     assert item_metadata["id"] == item_metadata["properties"]["linz:sufi"]
     assert (
-        item_metadata["assets"]["image/tiff; application=geotiff; profile=cloud-optimized"]["file:checksum"]
+        item_metadata["assets"]["visual"]["file:checksum"]
         == "1220b8f2e22e2d8059ec7c4b327bb695f6a8dc55bdb5f5865b0d2628867f16dca840"
     )
-    assert (item_metadata["assets"]["image/tiff; application=geotiff; profile=cloud-optimized"]["href"]) == "./72352.tiff"
+    assert (item_metadata["assets"]["visual"]["href"]) == "./72352.tiff"
     assert len(item_metadata["links"]) == 3
     for link in item_metadata["links"]:
         assert link["rel"] != "self"

--- a/topo_processor/metadata/metadata_validators/metadata_validator_stac.py
+++ b/topo_processor/metadata/metadata_validators/metadata_validator_stac.py
@@ -41,6 +41,9 @@ class MetadataValidatorStac(MetadataValidator):
     def validate_metadata_with_report(self, item: Item) -> Dict[str, list[str]]:
         errors_report: Dict[str, list[str]] = {}
         stac_item = item.create_stac().to_dict(include_self_link=False)
+        # get `json.dumps` to convert `tuple` into `array` to allow `jsonschema-rs` to validate
+        stac_item = json.loads(json.dumps(stac_item))
+
         get_log().debug(f"{self.name}:validate_metadata_with_report", itemId=stac_item["id"])
 
         for schema_uri in stac_item["stac_extensions"]:

--- a/topo_processor/stac/asset.py
+++ b/topo_processor/stac/asset.py
@@ -41,6 +41,16 @@ class Asset(Validity):
             self.properties["file:checksum"] = multihash_as_hex(self.source_path)
         return self.properties["file:checksum"]
 
+    def get_key(self) -> str:
+        if self.content_type:
+            if self.content_type == "image/tiff; application=geotiff; profile=cloud-optimized":
+                return "visual"
+            else:
+                return self.get_content_type()
+        if self.file_ext():
+            return self.file_ext()
+        return self.get_checksum()
+
     def create_stac(self) -> pystac.Asset:
         stac = pystac.Asset(href=self.href, extra_fields=self.properties, media_type=self.get_content_type())
         return stac

--- a/topo_processor/stac/tests/asset_test.py
+++ b/topo_processor/stac/tests/asset_test.py
@@ -13,3 +13,21 @@ def test_asset():
     checksum = asset.get_checksum()
     json_asset = asset.create_stac().to_dict()
     assert json_asset["file:checksum"] == checksum
+
+
+def test_asset_key_visual():
+    """validate value of asset object key for a tiff"""
+    source_path = os.path.abspath(os.path.join(os.getcwd(), "test_data", "tiffs", "SURVEY_1", "CONTROL.tiff"))
+    asset = Asset(source_path)
+    asset.content_type = "image/tiff; application=geotiff; profile=cloud-optimized"
+    key = asset.get_key()
+    assert key == "visual"
+
+
+def test_asset_key_no_content_type():
+    """validate value of asset object key for an unknown content type with an extension"""
+    source_path = os.path.abspath(os.path.join(os.getcwd(), "test_data", "tiffs", "SURVEY_1", "CONTROL.tiff"))
+    asset = Asset(source_path)
+    asset.content_type = ""
+    key = asset.get_key()
+    assert key == ".tiff"

--- a/topo_processor/stac/tests/asset_test.py
+++ b/topo_processor/stac/tests/asset_test.py
@@ -25,9 +25,19 @@ def test_asset_key_visual():
 
 
 def test_asset_key_no_content_type():
-    """validate value of asset object key for an unknown content type with an extension"""
+    """validate value of asset object key for an unknown content type with a file extension"""
     source_path = os.path.abspath(os.path.join(os.getcwd(), "test_data", "tiffs", "SURVEY_1", "CONTROL.tiff"))
     asset = Asset(source_path)
     asset.content_type = ""
     key = asset.get_key()
     assert key == ".tiff"
+
+
+def test_asset_key_no_content_type_no_file_ext(mocker):
+    """validate value of asset object key for an unknown content type with no file extension"""
+    source_path = os.path.abspath(os.path.join(os.getcwd(), "test_data", "tiffs", "SURVEY_1", "CONTROL.tiff"))
+    asset = Asset(source_path)
+    asset.content_type = ""
+    mocker.patch("topo_processor.stac.asset.Asset.file_ext", return_value="")
+    key = asset.get_key()
+    assert key == asset.get_checksum()

--- a/topo_processor/util/transfer_collection.py
+++ b/topo_processor/util/transfer_collection.py
@@ -45,9 +45,9 @@ def transfer_collection(collection: Collection, target: str):
             transfer_file(
                 asset.source_path, asset.get_checksum(), asset.get_content_type(), os.path.join(target, asset.target)
             )
-            stac_item.add_asset(
-                key=(asset.get_content_type() if asset.get_content_type() else asset.file_ext()), asset=asset.create_stac()
-            )
+            # key is set to "visual" for geotiffs, else the content type, file extension or checksum.
+            # Other key values will be added in future sprints.
+            stac_item.add_asset(key=asset.get_key(), asset=asset.create_stac())
             existing_asset_hrefs[asset.href] = asset
 
         # pystac v1.1.0


### PR DESCRIPTION
[https://linzgovt.atlassian.net/browse/TDE-188](https://linzgovt.atlassian.net/browse/TDE-188)
The Asset Object key was set to the media type.
This is an interim change (until we know more about the assets there will be) to set it to "visual" if the type is geotiff, then to follow the previous logic and set to the file extension if there is no media type. Then to the checksum if there is no extension.