### PR TITLE
perf: integration test (TDE-191)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,4 +29,4 @@ jobs:
           poetry run isort -rc . --check --diff
       - name: Test
         run: |
-          poetry run pytest --cov topo_processor
+          poetry run pytest --slow --cov topo_processor

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,10 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption("--slow", action="store_true", default=False, help="run slow tests")
+
+
+def pytest_runtest_setup(item):
+    if "slow" in item.keywords and not item.config.getoption("--slow"):
+        pytest.skip("need --slow option to run this test")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,3 +49,8 @@ module = [
     "linz_logger",
 ]
 ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+markers = [
+    "slow: marks tests as slow",
+]

--- a/topo_processor/cli/tests/upload_test.py
+++ b/topo_processor/cli/tests/upload_test.py
@@ -21,6 +21,7 @@ def setup():
     shutil.rmtree(target)
 
 
+@pytest.mark.slow
 def test_upload_local(setup):
     target = setup
     source = os.path.abspath(os.path.join(os.getcwd(), "test_data", "tiffs"))

--- a/topo_processor/file_system/tests/write_json_test.py
+++ b/topo_processor/file_system/tests/write_json_test.py
@@ -1,0 +1,26 @@
+import os
+import shutil
+from tempfile import mkdtemp
+
+import pytest
+
+from topo_processor.file_system.write_json import write_json
+
+
+@pytest.fixture(autouse=True)
+def setup():
+    """
+    This function creates a temporary directory and deletes it after each test.
+    See following link for details:
+    https://docs.pytest.org/en/stable/fixture.html#yield-fixtures-recommended
+    """
+    target = mkdtemp()
+    yield target
+    shutil.rmtree(target)
+
+
+def test_write_json(setup):
+    my_dict = {"foo": "foo", "bar": 1}
+    target = setup + "/test.json"
+    write_json(my_dict, target)
+    assert os.path.isfile(target)


### PR DESCRIPTION
### Change Description:

- Init a `pytest` config file to manage `slow` tests
- Mark integration test in `main_test.py` as `slow` to skip it by default

### Notes for Testing:

- Execute `pytest` with `--slow` argument to run the integration test or without to skip it

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned
- [ ] Linked to main issue for ZenHub board
