### PR TITLE
fix: asset object key redo (TDE-188)

### DIFF
--- a/topo_processor/cli/tests/upload_test.py
+++ b/topo_processor/cli/tests/upload_test.py
@@ -51,10 +51,10 @@ def test_upload_local(setup):
     assert item_metadata["properties"]["mission"] == "SURVEY_3"
     assert item_metadata["id"] == "72352"
     assert (
-        item_metadata["assets"]["image/tiff; application=geotiff; profile=cloud-optimized"]["file:checksum"]
+        item_metadata["assets"]["visual"]["file:checksum"]
         == "1220b8f2e22e2d8059ec7c4b327bb695f6a8dc55bdb5f5865b0d2628867f16dca840"
     )
-    assert (item_metadata["assets"]["image/tiff; application=geotiff; profile=cloud-optimized"]["href"]) == "./72352.tiff"
+    assert (item_metadata["assets"]["visual"]["href"]) == "./72352.tiff"
     assert len(item_metadata["links"]) == 3
     for link in item_metadata["links"]:
         assert link["rel"] != "self"

--- a/topo_processor/cli/upload.py
+++ b/topo_processor/cli/upload.py
@@ -49,7 +49,7 @@ def main(source, datatype, target, verbose):
 
     try:
         for collection in collection_store.values():
-            transfer_collection(collection, target)
+            transfer_collection(collection, target, data_type.value)
 
     finally:
         for collection in collection_store.values():

--- a/topo_processor/cli/upload.py
+++ b/topo_processor/cli/upload.py
@@ -49,7 +49,7 @@ def main(source, datatype, target, verbose):
 
     try:
         for collection in collection_store.values():
-            transfer_collection(collection, target, data_type.value)
+            transfer_collection(collection, target)
 
     finally:
         for collection in collection_store.values():

--- a/topo_processor/data/data_transformers/data_transformer_imagery_historic.py
+++ b/topo_processor/data/data_transformers/data_transformer_imagery_historic.py
@@ -42,6 +42,7 @@ class DataTransformerImageryHistoric(DataTransformer):
 
             cog_asset = stac.Asset(output_path)
             cog_asset.content_type = pystac.MediaType.COG
+            cog_asset.key_name = asset.key_name
             cog_asset.target = asset.target
             cog_asset.properties = asset.properties
             cog_asset_list.append(cog_asset)

--- a/topo_processor/metadata/metadata_loaders/metadata_loader_imagery_historic.py
+++ b/topo_processor/metadata/metadata_loaders/metadata_loader_imagery_historic.py
@@ -48,7 +48,7 @@ class MetadataLoaderImageryHistoric(MetadataLoader):
         asset_metadata = self.raw_metadata[filename]
 
         asset.target = f"{asset_metadata['survey']}/{asset_metadata['sufi']}{asset.file_ext()}"
-        asset.key_name = AssetKey.Visual.value
+        asset.key_name = AssetKey.Visual
         self.populate_item(asset_metadata, asset)
 
     def load_all_metadata(self, metadata_file: str) -> None:

--- a/topo_processor/metadata/metadata_loaders/metadata_loader_imagery_historic.py
+++ b/topo_processor/metadata/metadata_loaders/metadata_loader_imagery_historic.py
@@ -10,6 +10,7 @@ from linz_logger.logger import get_log
 from rasterio.enums import ColorInterp
 
 from topo_processor import stac
+from topo_processor.stac.asset_key import AssetKey
 from topo_processor.stac.providers import Providers
 from topo_processor.stac.store import get_collection, get_item
 from topo_processor.util import (
@@ -29,7 +30,6 @@ if TYPE_CHECKING:
 
 class MetadataLoaderImageryHistoric(MetadataLoader):
     name = "metadata.loader.imagery.historic"
-    asset_key_name = "visual"
     is_init = False
     raw_metadata: Dict[str, Dict[str, str]] = {}
 
@@ -48,7 +48,7 @@ class MetadataLoaderImageryHistoric(MetadataLoader):
         asset_metadata = self.raw_metadata[filename]
 
         asset.target = f"{asset_metadata['survey']}/{asset_metadata['sufi']}{asset.file_ext()}"
-        asset.key_name = self.asset_key_name
+        asset.key_name = AssetKey.Visual.value
         self.populate_item(asset_metadata, asset)
 
     def load_all_metadata(self, metadata_file: str) -> None:

--- a/topo_processor/metadata/metadata_loaders/metadata_loader_imagery_historic.py
+++ b/topo_processor/metadata/metadata_loaders/metadata_loader_imagery_historic.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 
 class MetadataLoaderImageryHistoric(MetadataLoader):
     name = "metadata.loader.imagery.historic"
+    asset_key_name = "visual"
     is_init = False
     raw_metadata: Dict[str, Dict[str, str]] = {}
 
@@ -47,6 +48,7 @@ class MetadataLoaderImageryHistoric(MetadataLoader):
         asset_metadata = self.raw_metadata[filename]
 
         asset.target = f"{asset_metadata['survey']}/{asset_metadata['sufi']}{asset.file_ext()}"
+        asset.key_name = self.asset_key_name
         self.populate_item(asset_metadata, asset)
 
     def load_all_metadata(self, metadata_file: str) -> None:

--- a/topo_processor/stac/asset.py
+++ b/topo_processor/stac/asset.py
@@ -18,6 +18,7 @@ class Asset(Validity):
     href: str
     properties = dict
     item: "Item"
+    key_name: str
 
     def __init__(self, source_path: str):
         super().__init__()
@@ -27,6 +28,7 @@ class Asset(Validity):
         self.needs_upload = True
         self.properties = {}
         self.item = None
+        self.key_name = None
 
     def file_ext(self) -> str:
         return path.splitext(self.target if self.target else self.source_path)[1]

--- a/topo_processor/stac/asset.py
+++ b/topo_processor/stac/asset.py
@@ -6,6 +6,8 @@ import pystac
 
 from topo_processor.util import Validity, multihash_as_hex
 
+from .asset_key import AssetKey
+
 if TYPE_CHECKING:
     from .item import Item
 
@@ -18,7 +20,7 @@ class Asset(Validity):
     href: str
     properties = dict
     item: "Item"
-    key_name: str
+    key_name: AssetKey
 
     def __init__(self, source_path: str):
         super().__init__()

--- a/topo_processor/stac/asset_key.py
+++ b/topo_processor/stac/asset_key.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class AssetKey(Enum):
+    Visual = "visual"
+    Thumbnail = "thumbnail"

--- a/topo_processor/stac/asset_key.py
+++ b/topo_processor/stac/asset_key.py
@@ -1,6 +1,6 @@
 from enum import Enum
 
 
-class AssetKey(Enum):
+class AssetKey(str, Enum):
     Visual = "visual"
     Thumbnail = "thumbnail"

--- a/topo_processor/util/tests/transfer_collection_test.py
+++ b/topo_processor/util/tests/transfer_collection_test.py
@@ -34,12 +34,12 @@ def test_fail_on_duplicate_assets(setup):
 
     cog_1 = Asset("./test_data/tiffs/SURVEY_1/CONTROL.tiff")
     cog_1.target = "fake_title/fake_target.tiff"
-    cog_1.key_name = AssetKey.Visual.value
+    cog_1.key_name = AssetKey.Visual
     item.add_asset(cog_1)
 
     cog_2 = Asset("test_data/tiffs/SURVEY_1/MULTIPLE_ASSET.tiff")
     cog_2.target = "fake_title/fake_target.tiff"
-    cog_2.key_name = AssetKey.Visual.value
+    cog_2.key_name = AssetKey.Visual
     item.add_asset(cog_2)
 
     with pytest.raises(Exception, match=r"./item_id.tiff already exists."):

--- a/topo_processor/util/tests/transfer_collection_test.py
+++ b/topo_processor/util/tests/transfer_collection_test.py
@@ -6,6 +6,7 @@ import dateutil
 import pytest
 
 from topo_processor.stac import Asset, Collection, Item
+from topo_processor.stac.asset_key import AssetKey
 from topo_processor.util.transfer_collection import transfer_collection
 
 
@@ -25,7 +26,7 @@ def test_fail_on_duplicate_assets(setup):
     target = setup
     collection = Collection("fake_title")
     collection.description = "fake_description"
-    collection.license = "face_license"
+    collection.license = "fake_license"
     item = Item("item_id")
     item.datetime = datetime.now()
     collection.add_item(item)
@@ -33,11 +34,32 @@ def test_fail_on_duplicate_assets(setup):
 
     cog_1 = Asset("./test_data/tiffs/SURVEY_1/CONTROL.tiff")
     cog_1.target = "fake_title/fake_target.tiff"
+    cog_1.key_name = AssetKey.Visual.value
     item.add_asset(cog_1)
 
     cog_2 = Asset("test_data/tiffs/SURVEY_1/MULTIPLE_ASSET.tiff")
     cog_2.target = "fake_title/fake_target.tiff"
+    cog_2.key_name = AssetKey.Thumbnail.value
     item.add_asset(cog_2)
 
     with pytest.raises(Exception, match=r"./item_id.tiff already exists."):
+        transfer_collection(item.collection, target)
+
+
+def test_asset_key_not_in_list(setup):
+    target = setup
+    collection = Collection("fake_title")
+    collection.description = "fake_description"
+    collection.license = "face_license"
+    item = Item("item_id")
+    item.datetime = datetime.now()
+    collection.add_item(item)
+    item.collection = collection
+
+    test_asset = Asset("./test_data/tiffs/SURVEY_1/CONTROL.tiff")
+    test_asset.target = "fake_title/fake_target.tiff"
+    test_asset.key_name = None
+    item.add_asset(test_asset)
+
+    with pytest.raises(Exception, match=r"No asset key set for asset ./item_id.tiff"):
         transfer_collection(item.collection, target)

--- a/topo_processor/util/tests/transfer_collection_test.py
+++ b/topo_processor/util/tests/transfer_collection_test.py
@@ -39,7 +39,7 @@ def test_fail_on_duplicate_assets(setup):
 
     cog_2 = Asset("test_data/tiffs/SURVEY_1/MULTIPLE_ASSET.tiff")
     cog_2.target = "fake_title/fake_target.tiff"
-    cog_2.key_name = AssetKey.Thumbnail.value
+    cog_2.key_name = AssetKey.Visual.value
     item.add_asset(cog_2)
 
     with pytest.raises(Exception, match=r"./item_id.tiff already exists."):

--- a/topo_processor/util/transfer_collection.py
+++ b/topo_processor/util/transfer_collection.py
@@ -36,7 +36,6 @@ def transfer_collection(collection: Collection, target: str):
 
         existing_asset_hrefs = {}
 
-
         for asset in item.assets:
 
             if not asset.needs_upload:
@@ -48,9 +47,7 @@ def transfer_collection(collection: Collection, target: str):
                 asset.source_path, asset.get_checksum(), asset.get_content_type(), os.path.join(target, asset.target)
             )
             if asset.key_name:
-                stac_item.add_asset(
-                    key=asset.key_name, asset=asset.create_stac()
-                )
+                stac_item.add_asset(key=asset.key_name, asset=asset.create_stac())
             else:
                 stac_item.add_asset(
                     key=(asset.get_content_type() if asset.get_content_type() else asset.file_ext()), asset=asset.create_stac()

--- a/topo_processor/util/transfer_collection.py
+++ b/topo_processor/util/transfer_collection.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from topo_processor.stac import Collection
 
 
-def transfer_collection(collection: Collection, target: str):
+def transfer_collection(collection: Collection, target: str, datatype: str):
     stac_collection = collection.create_stac()
     # pystac v1.1.0
     # Required to remove cwd from collection self_href,
@@ -45,9 +45,12 @@ def transfer_collection(collection: Collection, target: str):
             transfer_file(
                 asset.source_path, asset.get_checksum(), asset.get_content_type(), os.path.join(target, asset.target)
             )
-            stac_item.add_asset(
-                key=(asset.get_content_type() if asset.get_content_type() else asset.file_ext()), asset=asset.create_stac()
-            )
+            if datatype == "imagery.historic":
+                stac_item.add_asset(key="visual", asset=asset.create_stac())
+            else:
+                stac_item.add_asset(
+                    key=(asset.get_content_type() if asset.get_content_type() else asset.file_ext()), asset=asset.create_stac()
+                )
             existing_asset_hrefs[asset.href] = asset
 
         # pystac v1.1.0

--- a/topo_processor/util/transfer_collection.py
+++ b/topo_processor/util/transfer_collection.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from topo_processor.stac import Collection
 
 
-def transfer_collection(collection: Collection, target: str, datatype: str):
+def transfer_collection(collection: Collection, target: str):
     stac_collection = collection.create_stac()
     # pystac v1.1.0
     # Required to remove cwd from collection self_href,
@@ -36,7 +36,9 @@ def transfer_collection(collection: Collection, target: str, datatype: str):
 
         existing_asset_hrefs = {}
 
+
         for asset in item.assets:
+
             if not asset.needs_upload:
                 continue
             asset.href = f"./{item.id}{asset.file_ext()}"
@@ -45,8 +47,10 @@ def transfer_collection(collection: Collection, target: str, datatype: str):
             transfer_file(
                 asset.source_path, asset.get_checksum(), asset.get_content_type(), os.path.join(target, asset.target)
             )
-            if datatype == "imagery.historic":
-                stac_item.add_asset(key="visual", asset=asset.create_stac())
+            if asset.key_name:
+                stac_item.add_asset(
+                    key=asset.key_name, asset=asset.create_stac()
+                )
             else:
                 stac_item.add_asset(
                     key=(asset.get_content_type() if asset.get_content_type() else asset.file_ext()), asset=asset.create_stac()

--- a/topo_processor/util/transfer_collection.py
+++ b/topo_processor/util/transfer_collection.py
@@ -8,6 +8,7 @@ from pystac.catalog import CatalogType
 
 from topo_processor.file_system.transfer import transfer_file
 from topo_processor.file_system.write_json import write_json
+from topo_processor.stac.asset_key import AssetKey
 
 if TYPE_CHECKING:
     from topo_processor.stac import Collection
@@ -46,12 +47,11 @@ def transfer_collection(collection: Collection, target: str):
             transfer_file(
                 asset.source_path, asset.get_checksum(), asset.get_content_type(), os.path.join(target, asset.target)
             )
-            if asset.key_name:
-                stac_item.add_asset(key=asset.key_name, asset=asset.create_stac())
+            if not asset.key_name:
+                raise Exception(f"No asset key set for asset {asset.href}")
             else:
-                stac_item.add_asset(
-                    key=(asset.get_content_type() if asset.get_content_type() else asset.file_ext()), asset=asset.create_stac()
-                )
+                stac_item.add_asset(key=asset.key_name, asset=asset.create_stac())
+
             existing_asset_hrefs[asset.href] = asset
 
         # pystac v1.1.0


### PR DESCRIPTION
[https://linzgovt.atlassian.net/browse/TDE-188](https://linzgovt.atlassian.net/browse/TDE-188)

Note: should I check against the enumerator when adding the key in `topo_processor/util/transfer_collection.py`, rather than assume an enumerator value has been used?