### PR TITLE
ci: add mypy run to the CI workflow (TDE-184)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,6 @@ jobs:
       - name: Test
         run: |
           poetry run pytest --slow --cov topo_processor
+      - name: Mypy
+        run: |
+          poetry run mypy .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,28 @@ profile = "black"
 [tool.mypy]
 show_error_codes = true
 strict = true
+disable_error_code = [
+    "attr-defined",
+    "no-untyped-def",
+    "no-untyped-call",
+    "no-any-return",
+    "operator",
+    "misc",
+    "assignment",
+    "type-arg",
+    "import",
+    "var-annotated",
+    "list-item",
+    "type-var",
+    "override",
+    "comparison-overlap",
+    "name-defined",
+    "return-value",
+    "valid-type",
+    "func-returns-value",
+    "union-attr",
+    "arg-type",
+]
 
 [[tool.mypy.overrides]]
 module = [


### PR DESCRIPTION
### Change Description:
Mypy configuration is not checking all the current errors by default. That means `mypy .` run on the current code base will not raise any error.
Mypy run is added to the CI workflow. `mypy .` will be run at every build on the GitHub repository.

### Notes for Testing:
Run `mypy .` at the project root. Make sure that it returns `Success: no issues found in [...]`
