### PR TITLE
fix: add missing typing for function arguments [arg-type] (TDE-263)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,27 @@ profile = "black"
 [tool.mypy]
 show_error_codes = true
 strict = true
+disable_error_code = [
+    "attr-defined",
+    "no-untyped-def",
+    "no-untyped-call",
+    "no-any-return",
+    "operator",
+    "misc",
+    "assignment",
+    "type-arg",
+    "import",
+    "var-annotated",
+    "list-item",
+    "type-var",
+    "override",
+    "comparison-overlap",
+    "name-defined",
+    "return-value",
+    "valid-type",
+    "func-returns-value",
+    "union-attr",
+]
 
 [[tool.mypy.overrides]]
 module = [

--- a/topo_processor/cli/validate.py
+++ b/topo_processor/cli/validate.py
@@ -34,7 +34,7 @@ from topo_processor.util.configuration import temp_folder
     is_flag=True,
     help="Use verbose to display trace logs (it might be slower).",
 )
-def main(item: str, collection: str, metadata: str, verbose: str) -> None:
+def main(item: bool, collection: bool, metadata: str, verbose: str) -> None:
     if verbose:
         set_level(LogLevel.trace)
     else:

--- a/topo_processor/file_system/write_json.py
+++ b/topo_processor/file_system/write_json.py
@@ -1,4 +1,5 @@
 import json
+from typing import Dict
 
 import pystac
 from linz_logger import get_log
@@ -8,7 +9,7 @@ from topo_processor.util import time_in_ms
 from .get_fs import get_fs
 
 
-def write_json(dictionary: str, target_json):
+def write_json(dictionary: Dict, target_json):
     start_time = time_in_ms()
     with get_fs(target_json).open(target_json, "w", encoding="utf8", ContentType=pystac.MediaType.JSON) as f1:
         f1.write(json.dumps(dictionary, indent=4, ensure_ascii=False))

--- a/topo_processor/metadata/metadata_loaders/tests/metadata_loader_imagery_historic_test.py
+++ b/topo_processor/metadata/metadata_loaders/tests/metadata_loader_imagery_historic_test.py
@@ -292,7 +292,7 @@ def test_invalid_centroid_string() -> None:
     centroid = {"lat": "-41.28509", "lon": "174.77442"}
     metadata_loader_imagery_historic = MetadataLoaderImageryHistoric()
     assert not metadata_loader_imagery_historic.is_valid_centroid(item, centroid)  # type: ignore [arg-type]
-    # Ignore typing above because it interfers with our test.
+    # Ignore typing above because it interferes with our test.
     assert str(item.log[0]["error"]) == "stac field 'proj:centroid' has invalid lat value: -41.28509, instance: <class 'str'>"
 
 

--- a/topo_processor/metadata/metadata_loaders/tests/metadata_loader_imagery_historic_test.py
+++ b/topo_processor/metadata/metadata_loaders/tests/metadata_loader_imagery_historic_test.py
@@ -291,7 +291,8 @@ def test_invalid_centroid_string() -> None:
     item = stac.Item(source_path)
     centroid = {"lat": "-41.28509", "lon": "174.77442"}
     metadata_loader_imagery_historic = MetadataLoaderImageryHistoric()
-    assert not metadata_loader_imagery_historic.is_valid_centroid(item, centroid)
+    assert not metadata_loader_imagery_historic.is_valid_centroid(item, centroid)  # type: ignore
+    # Ignore typing above because it interfers with our test.
     assert str(item.log[0]["error"]) == "stac field 'proj:centroid' has invalid lat value: -41.28509, instance: <class 'str'>"
 
 

--- a/topo_processor/metadata/metadata_loaders/tests/metadata_loader_imagery_historic_test.py
+++ b/topo_processor/metadata/metadata_loaders/tests/metadata_loader_imagery_historic_test.py
@@ -291,7 +291,7 @@ def test_invalid_centroid_string() -> None:
     item = stac.Item(source_path)
     centroid = {"lat": "-41.28509", "lon": "174.77442"}
     metadata_loader_imagery_historic = MetadataLoaderImageryHistoric()
-    assert not metadata_loader_imagery_historic.is_valid_centroid(item, centroid)  # type: ignore
+    assert not metadata_loader_imagery_historic.is_valid_centroid(item, centroid)  # type: ignore [arg-type]
     # Ignore typing above because it interfers with our test.
     assert str(item.log[0]["error"]) == "stac field 'proj:centroid' has invalid lat value: -41.28509, instance: <class 'str'>"
 

--- a/topo_processor/stac/asset.py
+++ b/topo_processor/stac/asset.py
@@ -19,7 +19,7 @@ class Asset(Validity):
     content_type: str
     needs_upload = bool
     href: str
-    properties: Dict[str, str]
+    properties: Dict[str, Any]
     item: "Item"
     key_name: AssetKey
 

--- a/topo_processor/stac/collection.py
+++ b/topo_processor/stac/collection.py
@@ -4,7 +4,7 @@ import os
 from datetime import datetime
 from shutil import rmtree
 from tempfile import mkdtemp
-from typing import TYPE_CHECKING, Dict, List
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import pystac
 import ulid
@@ -34,7 +34,7 @@ class Collection(Validity):
     description: str
     license: str
     items: Dict[str, "Item"]
-    linz_providers: List[LinzProvider]
+    linz_providers: List[Dict[str, Any]]
     providers: List[pystac.Provider]
     schema: str
     extra_fields: Dict[str, Any]
@@ -96,7 +96,7 @@ class Collection(Validity):
             os.mkdir(temp_dir)
         return temp_dir
 
-    def get_temporal_extent(self) -> List[datetime]:
+    def get_temporal_extent(self) -> List[Optional[datetime]]:
         dates: List[datetime] = []
 
         for item in self.items.values():

--- a/topo_processor/stac/tests/lds_cache_test.py
+++ b/topo_processor/stac/tests/lds_cache_test.py
@@ -1,16 +1,20 @@
+from datetime import datetime
+
 import pystac
 import pytest
+from pystac.collection import Extent, SpatialExtent, TemporalExtent
 
 import topo_processor.stac.lds_cache as lds_cache
 
 
 def test_get_last_version():
-    collection: pystac.Collection = pystac.Collection(id="1234", description="fake", extent=None)
+    extent = Extent(SpatialExtent([0.0]), TemporalExtent([datetime.now(), None]))
+    collection: pystac.Collection = pystac.Collection(id="1234", description="fake", extent=extent)
     link_a: pystac.Link = pystac.Link(rel=pystac.RelType.SELF, target="./collection.json")
     link_b: pystac.Link = pystac.Link(rel="layer", target="https://layer/1234")
     link_c: pystac.Link = pystac.Link(rel=pystac.RelType.ITEM, target="./1234_100000.json")
     link_d: pystac.Link = pystac.Link(rel=pystac.RelType.ITEM, target="./1234_100001.json")
-    collection.add_links((link_a, link_b, link_c, link_d))
+    collection.add_links([link_a, link_b, link_c, link_d])
 
     assert lds_cache.get_last_version(collection) == "100001"
 

--- a/topo_processor/stac/validation.py
+++ b/topo_processor/stac/validation.py
@@ -1,5 +1,5 @@
 import os
-from typing import List, Union
+from typing import Dict, Union
 
 from linz_logger import get_log
 
@@ -58,7 +58,7 @@ def validate_stac(metadata_file: str = "", validate_item: bool = True, validate_
     )
 
 
-def validate_store(store: List[Union[Item, Collection]]) -> ValidateReport:
+def validate_store(store: Dict[str, Union[Item, Collection]]) -> ValidateReport:
     validate_report: ValidateReport = ValidateReport()
 
     for stac_object in store.values():

--- a/topo_processor/util/__init__.py
+++ b/topo_processor/util/__init__.py
@@ -1,5 +1,5 @@
 from .checksum import multihash_as_hex
-from .configuration import configuration
+from .configuration import aws_profile, aws_role_config_path, lds_cache_bucket
 from .conversions import (
     historical_imagery_photo_type_to_linz_geospatial_type,
     nzt_datetime_to_utc_datetime,

--- a/topo_processor/util/aws_credentials.py
+++ b/topo_processor/util/aws_credentials.py
@@ -1,12 +1,10 @@
 import json
-import os
 from typing import Dict
 
 import boto3
-from linz_logger import get_log
+from configuration import aws_profile, aws_role_config_path
 
 from topo_processor.file_system.get_fs import bucket_name_from_path
-from topo_processor.util.configuration import aws_role_config_path
 
 
 class Credentials:
@@ -20,12 +18,7 @@ class Credentials:
         self.token = token
 
 
-aws_profile: str = ""
-if os.getenv("AWS_PROFILE"):
-    aws_profile = os.getenv("AWS_PROFILE")
-else:
-    get_log().warning("Environment variable not set", envVariableName="AWS_PROFILE")
-session: boto3.Session = boto3.Session(profile_name=aws_profile)
+session = boto3.Session(profile_name=aws_profile)
 client: boto3.client = session.client("sts")
 bucket_roles: Dict = {}
 

--- a/topo_processor/util/aws_credentials.py
+++ b/topo_processor/util/aws_credentials.py
@@ -2,9 +2,9 @@ import json
 from typing import Dict
 
 import boto3
-from configuration import aws_profile, aws_role_config_path
 
 from topo_processor.file_system.get_fs import bucket_name_from_path
+from topo_processor.util.configuration import aws_profile, aws_role_config_path
 
 
 class Credentials:

--- a/topo_processor/util/aws_credentials.py
+++ b/topo_processor/util/aws_credentials.py
@@ -3,6 +3,7 @@ import os
 from typing import Dict
 
 import boto3
+from linz_logger import get_log
 
 from topo_processor.file_system.get_fs import bucket_name_from_path
 from topo_processor.util.configuration import aws_role_config_path
@@ -19,7 +20,12 @@ class Credentials:
         self.token = token
 
 
-session = boto3.Session(profile_name=os.getenv("AWS_PROFILE"))
+aws_profile: str = ""
+if os.getenv("AWS_PROFILE"):
+    aws_profile = os.getenv("AWS_PROFILE")
+else:
+    get_log().warning("Environment variable not set", envVariableName="AWS_PROFILE")
+session: boto3.Session = boto3.Session(profile_name=aws_profile)
 client: boto3.client = session.client("sts")
 bucket_roles: Dict = {}
 

--- a/topo_processor/util/aws_files.py
+++ b/topo_processor/util/aws_files.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Union
+from typing import Any, Dict
 from urllib.parse import urlparse
 
 import boto3
@@ -39,7 +39,7 @@ def s3_download(source_path: str, dest_path: str) -> None:
     )
 
 
-def load_file_content(bucket_name: str, object_path: str) -> Union[bytes, Any]:
+def load_file_content(bucket_name: str, object_path: str) -> Dict[str, Any]:
     credentials: Credentials = get_credentials(bucket_name)
 
     s3 = boto3.resource(
@@ -52,9 +52,11 @@ def load_file_content(bucket_name: str, object_path: str) -> Union[bytes, Any]:
     object_content = s3.Object(bucket_name=bucket_name, key=object_path)
 
     if object_path.endswith(".json"):
-        return json.loads(object_content.get()["Body"].read())
+        json_result: Dict[str, Any] = json.loads(object_content.get()["Body"].read())
+        return json_result
 
-    return object_content.get()["Body"].read()
+    result: Dict[str, Any] = object_content.get()["Body"].read()
+    return result
 
 
 def build_s3_path(bucket_name: str, object_path: str) -> str:

--- a/topo_processor/util/configuration.py
+++ b/topo_processor/util/configuration.py
@@ -1,10 +1,9 @@
-import os
+from os import environ, path
 from tempfile import mkdtemp
 
-from dotenv import dotenv_values
+from dotenv import load_dotenv
 
-configuration = dotenv_values(".env")
-
-lds_cache_bucket: str = configuration["LDS_CACHE_BUCKET"]
-aws_role_config_path = os.path.expanduser(configuration["AWS_ROLES_CONFIG"])
+load_dotenv()
+lds_cache_bucket: str = environ.get("LDS_CACHE_BUCKET")
+aws_role_config_path: str = path.expanduser(environ.get("AWS_ROLES_CONFIG"))
 temp_folder: str = mkdtemp()

--- a/topo_processor/util/configuration.py
+++ b/topo_processor/util/configuration.py
@@ -6,4 +6,5 @@ from dotenv import load_dotenv
 load_dotenv()
 lds_cache_bucket: str = environ.get("LDS_CACHE_BUCKET")
 aws_role_config_path: str = path.expanduser(environ.get("AWS_ROLES_CONFIG"))
+aws_profile: str = environ.get("AWS_PROFILE")
 temp_folder: str = mkdtemp()

--- a/topo_processor/util/time.py
+++ b/topo_processor/util/time.py
@@ -1,13 +1,13 @@
 import time
 from datetime import datetime
-from typing import List
+from typing import List, Union
 
 
 def time_in_ms() -> float:
     return time.time() * 1000
 
 
-def get_min_max_interval(times: List[datetime]) -> List[datetime]:
+def get_min_max_interval(times: List[datetime]) -> List[Union[datetime, None]]:
     min_date = None
     max_date = None
 


### PR DESCRIPTION
### Change Description:
Add the missing typing for function arguments. That is check by `Mypy` with error code `arg-type`

### Notes for Testing:
run `mypy .` should not display any error.
