### PR TITLE
feat: create Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM osgeo/gdal:ubuntu-small-latest
+
+#Install Poetry
+RUN apt-get update
+RUN apt-get install python3-pip -y
+RUN pip install poetry
+RUN poetry config virtualenvs.create false
+
+ENV IS_DOCKER=true
+
+#Add Poetry config and scripts
+COPY . /app/topo-processor
+
+WORKDIR /app/topo-processor
+
+RUN poetry install --no-dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get install python3-pip -y
 RUN pip install poetry
 RUN poetry config virtualenvs.create false
 
+#Set environment variable to prevent GDAL running in Docker
 ENV IS_DOCKER=true
 
 #Add Poetry config and scripts

--- a/topo_processor/cog/create_cog.py
+++ b/topo_processor/cog/create_cog.py
@@ -6,7 +6,10 @@ from topo_processor.util.aws_credentials import Credentials, get_credentials
 
 
 def create_cog(input_path: str, output_path: str) -> Command:
-    cmd = Command("gdal_translate", {"container": "osgeo/gdal", "tag": "ubuntu-small-latest"})
+    if os.environ.get("IS_DOCKER") == "true":
+        cmd = Command("gdal_translate")
+    else:
+        cmd = Command("gdal_translate", {"container": "osgeo/gdal", "tag": "ubuntu-small-latest"})
     if is_s3_path(input_path):
         credentials: Credentials = get_credentials(bucket_name_from_path(input_path))
         cmd.env(f"AWS_ACCESS_KEY_ID={credentials.access_key}")


### PR DESCRIPTION
This is part of [https://toitutewhenua.atlassian.net/browse/TDE-220](https://toitutewhenua.atlassian.net/browse/TDE-220)

To run the topo-processor inside Docker on your local workstation:
From the directory where the Dockerfile is:

`docker build -t topo-processor-image .`
`docker run --name topo-processor -dt topo-processor-image:latest`
`docker exec -it topo-processor /bin/bash`
`./upload --source test_data --target build/test_output --datatype imagery.historic --verbose`
(so you can explore the filesystem and see the output without mapping any drives).

This Docker image is a starting point to be used with the AWS Batch infrastructure, as in the topo-aws-infrastrure gdalinfo code. It will probably need some AWS account helper stuff to be added.

Further changes will be needed to the topo-processor code to allow it to receive batch jobs from the orchestration.
