### PR TITLE
fix: typing annotation None to Generator for pytest setup functions (TDE-285)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,7 @@
+import shutil
+from tempfile import mkdtemp
+from typing import Generator
+
 import pytest
 
 
@@ -8,3 +12,15 @@ def pytest_addoption(parser) -> None:  # type: ignore
 def pytest_runtest_setup(item) -> None:  # type: ignore
     if "slow" in item.keywords and not item.config.getoption("--slow"):
         pytest.skip("need --slow option to run this test")
+
+
+@pytest.fixture(autouse=True)
+def setup() -> Generator[str, None, None]:
+    """
+    This function creates a temporary directory and deletes it after each test.
+    See following link for details:
+    https://docs.pytest.org/en/stable/fixture.html#yield-fixtures-recommended
+    """
+    target = mkdtemp()
+    yield target
+    shutil.rmtree(target)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ strict = true
 disable_error_code = [
     "no-untyped-call",
     "operator",
-    "misc",
     "import",
     "var-annotated",
     "comparison-overlap",

--- a/topo_processor/cli/tests/upload_test.py
+++ b/topo_processor/cli/tests/upload_test.py
@@ -3,6 +3,7 @@ import os
 import shutil
 import subprocess
 from tempfile import mkdtemp
+from typing import Generator
 
 import pytest
 
@@ -10,7 +11,7 @@ from topo_processor.stac.stac_extensions import StacExtensions
 
 
 @pytest.fixture(autouse=True)
-def setup() -> None:
+def setup() -> Generator[str, None, None]:
     """
     This function creates a temporary directory and deletes it after each test.
     See following link for details:

--- a/topo_processor/cli/tests/upload_test.py
+++ b/topo_processor/cli/tests/upload_test.py
@@ -1,29 +1,14 @@
 import json
 import os
-import shutil
 import subprocess
-from tempfile import mkdtemp
-from typing import Generator
 
 import pytest
 
 from topo_processor.stac.stac_extensions import StacExtensions
 
 
-@pytest.fixture(autouse=True)
-def setup() -> Generator[str, None, None]:
-    """
-    This function creates a temporary directory and deletes it after each test.
-    See following link for details:
-    https://docs.pytest.org/en/stable/fixture.html#yield-fixtures-recommended
-    """
-    target = mkdtemp()
-    yield target
-    shutil.rmtree(target)
-
-
 @pytest.mark.slow
-def test_upload_local(setup) -> None:  # type: ignore
+def test_upload_local(setup: str) -> None:
     target = setup
     source = os.path.abspath(os.path.join(os.getcwd(), "test_data", "tiffs"))
     command = os.path.join(os.getcwd(), "upload")

--- a/topo_processor/file_system/tests/transfer_test.py
+++ b/topo_processor/file_system/tests/transfer_test.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 from tempfile import mkdtemp
+from typing import Generator
 
 import pytest
 
@@ -9,7 +10,7 @@ from topo_processor.file_system.transfer import transfer_file
 
 
 @pytest.fixture(autouse=True)
-def setup() -> None:
+def setup() -> Generator[str, None, None]:
     """
     This function creates a temporary directory and deletes it after each test.
     See following link for details:

--- a/topo_processor/file_system/tests/transfer_test.py
+++ b/topo_processor/file_system/tests/transfer_test.py
@@ -1,7 +1,4 @@
 import os
-import shutil
-from tempfile import mkdtemp
-from typing import Generator
 
 import pytest
 
@@ -9,19 +6,7 @@ from topo_processor.file_system.get_fs import get_fs
 from topo_processor.file_system.transfer import transfer_file
 
 
-@pytest.fixture(autouse=True)
-def setup() -> Generator[str, None, None]:
-    """
-    This function creates a temporary directory and deletes it after each test.
-    See following link for details:
-    https://docs.pytest.org/en/stable/fixture.html#yield-fixtures-recommended
-    """
-    target = mkdtemp()
-    yield target
-    shutil.rmtree(target)
-
-
-def test_transfer_local(setup) -> None:  # type: ignore
+def test_transfer_local(setup: str) -> None:
     dest_path = f"{setup}/test.tiff"
     input_path = os.path.join(os.getcwd(), "test_data/tiffs/SURVEY_1/CONTROL.tiff")
     transfer_file(input_path, "fakechecksum", "image/tiff", dest_path)

--- a/topo_processor/file_system/tests/write_json_test.py
+++ b/topo_processor/file_system/tests/write_json_test.py
@@ -1,26 +1,11 @@
 import os
-import shutil
-from tempfile import mkdtemp
-from typing import Generator
 
 import pytest
 
 from topo_processor.file_system.write_json import write_json
 
 
-@pytest.fixture(autouse=True)
-def setup() -> Generator[str, None, None]:
-    """
-    This function creates a temporary directory and deletes it after each test.
-    See following link for details:
-    https://docs.pytest.org/en/stable/fixture.html#yield-fixtures-recommended
-    """
-    target = mkdtemp()
-    yield target
-    shutil.rmtree(target)
-
-
-def test_write_json(setup) -> None:  # type: ignore
+def test_write_json(setup: str) -> None:
     my_dict = {"foo": "foo", "bar": 1}
     target = setup + "/test.json"
     write_json(my_dict, target)

--- a/topo_processor/file_system/tests/write_json_test.py
+++ b/topo_processor/file_system/tests/write_json_test.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 from tempfile import mkdtemp
+from typing import Generator
 
 import pytest
 
@@ -8,7 +9,7 @@ from topo_processor.file_system.write_json import write_json
 
 
 @pytest.fixture(autouse=True)
-def setup() -> None:
+def setup() -> Generator[str, None, None]:
     """
     This function creates a temporary directory and deletes it after each test.
     See following link for details:

--- a/topo_processor/util/tests/aws_files_test.py
+++ b/topo_processor/util/tests/aws_files_test.py
@@ -1,5 +1,6 @@
 import shutil
 from tempfile import mkdtemp
+from typing import Generator
 
 import pytest
 
@@ -7,7 +8,7 @@ from topo_processor.util.aws_files import build_s3_path
 
 
 @pytest.fixture(autouse=True)
-def setup() -> None:
+def setup() -> Generator[str, None, None]:
     """
     This function creates a temporary directory and deletes it after each test.
     See following link for details:

--- a/topo_processor/util/tests/aws_files_test.py
+++ b/topo_processor/util/tests/aws_files_test.py
@@ -1,26 +1,8 @@
-import shutil
-from tempfile import mkdtemp
-from typing import Generator
-
 import pytest
 
 from topo_processor.util.aws_files import build_s3_path
 
 
-@pytest.fixture(autouse=True)
-def setup() -> Generator[str, None, None]:
-    """
-    This function creates a temporary directory and deletes it after each test.
-    See following link for details:
-    https://docs.pytest.org/en/stable/fixture.html#yield-fixtures-recommended
-    """
-    target = mkdtemp()
-    yield target
-    shutil.rmtree(target)
-
-
 # Add test with AWS mock
-
-
 def test_build_s3_path() -> None:
     assert build_s3_path("test-bucket", "/test-folder/object.ext") == "s3://test-bucket/test-folder/object.ext"

--- a/topo_processor/util/tests/files_test.py
+++ b/topo_processor/util/tests/files_test.py
@@ -1,27 +1,12 @@
 import gzip
 import os
-import shutil
-from tempfile import mkdtemp
-from typing import Generator
 
 import pytest
 
 from topo_processor.util.gzip import is_gzip_file
 
 
-@pytest.fixture(autouse=True)
-def setup() -> Generator[str, None, None]:
-    """
-    This function creates a temporary directory and deletes it after each test.
-    See following link for details:
-    https://docs.pytest.org/en/stable/fixture.html#yield-fixtures-recommended
-    """
-    target = mkdtemp()
-    yield target
-    shutil.rmtree(target)
-
-
-def test_is_gzip_file_true(setup) -> None:  # type: ignore
+def test_is_gzip_file_true(setup: str) -> None:
     compressed_file = os.path.abspath(os.path.join(setup, "file.gz"))
     cf = gzip.open(compressed_file, "wb")
     cf.write("test".encode("utf-8"))
@@ -30,7 +15,7 @@ def test_is_gzip_file_true(setup) -> None:  # type: ignore
     assert is_gzip_file(compressed_file) == True
 
 
-def test_is_gzip_file_false(setup) -> None:  # type: ignore
+def test_is_gzip_file_false(setup: str) -> None:
     file = os.path.abspath(os.path.join(setup, "file.txt"))
     cf = open(file, "wb")
     cf.write("test".encode("utf-8"))

--- a/topo_processor/util/tests/files_test.py
+++ b/topo_processor/util/tests/files_test.py
@@ -2,6 +2,7 @@ import gzip
 import os
 import shutil
 from tempfile import mkdtemp
+from typing import Generator
 
 import pytest
 
@@ -9,7 +10,7 @@ from topo_processor.util.gzip import is_gzip_file
 
 
 @pytest.fixture(autouse=True)
-def setup() -> None:
+def setup() -> Generator[str, None, None]:
     """
     This function creates a temporary directory and deletes it after each test.
     See following link for details:

--- a/topo_processor/util/tests/time_test.py
+++ b/topo_processor/util/tests/time_test.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 from typing import List
 
-from topo_processor.util.files import get_file_update_time
 from topo_processor.util.time import get_min_max_interval
 
 

--- a/topo_processor/util/tests/transfer_collection_test.py
+++ b/topo_processor/util/tests/transfer_collection_test.py
@@ -3,6 +3,7 @@ import os
 import shutil
 from datetime import datetime
 from tempfile import mkdtemp
+from typing import Generator
 
 import pytest
 
@@ -15,7 +16,7 @@ from topo_processor.util.transfer_collection import transfer_collection
 
 
 @pytest.fixture(autouse=True)
-def setup() -> None:
+def setup() -> Generator[str, None, None]:
     """
     This function creates a temporary directory and deletes it after each test.
     See following link for details:

--- a/topo_processor/util/tests/transfer_collection_test.py
+++ b/topo_processor/util/tests/transfer_collection_test.py
@@ -1,9 +1,6 @@
 import json
 import os
-import shutil
 from datetime import datetime
-from tempfile import mkdtemp
-from typing import Generator
 
 import pytest
 
@@ -15,19 +12,7 @@ from topo_processor.stac.item import Item
 from topo_processor.util.transfer_collection import transfer_collection
 
 
-@pytest.fixture(autouse=True)
-def setup() -> Generator[str, None, None]:
-    """
-    This function creates a temporary directory and deletes it after each test.
-    See following link for details:
-    https://docs.pytest.org/en/stable/fixture.html#yield-fixtures-recommended
-    """
-    target = mkdtemp()
-    yield target
-    shutil.rmtree(target)
-
-
-def test_fail_on_duplicate_assets(setup) -> None:  # type: ignore
+def test_fail_on_duplicate_assets(setup: str) -> None:
     target = setup
     collection = Collection("fake_title")
     collection.description = "fake_description"
@@ -52,7 +37,7 @@ def test_fail_on_duplicate_assets(setup) -> None:  # type: ignore
         transfer_collection(item.collection, target)
 
 
-def test_asset_key_not_in_list(setup) -> None:  # type: ignore
+def test_asset_key_not_in_list(setup: str) -> None:
     target = setup
     collection = Collection("fake_title")
     collection.description = "fake_description"
@@ -72,7 +57,7 @@ def test_asset_key_not_in_list(setup) -> None:  # type: ignore
         transfer_collection(item.collection, target)
 
 
-def test_generate_summaries(setup) -> None:  # type: ignore
+def test_generate_summaries(setup: str) -> None:
     target = setup
     collection = Collection("fake_title")
     collection.description = "fake_description"


### PR DESCRIPTION
### Change Description:
Use `Generator` type for return type annotation of `pytest` `setup()` functions.