### PR TITLE
config: remove unused mypy error code from the exclusion list (TDE-287)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,12 +48,7 @@ profile = "black"
 show_error_codes = true
 strict = true
 disable_error_code = [
-    "no-untyped-call",
     "import",
-    "comparison-overlap",
-    "name-defined",
-    "valid-type",
-    "func-returns-value",
 ]
 
 [[tool.mypy.overrides]]


### PR DESCRIPTION
### Change Description:
The exclusion list for the mypy error code has only the `import` error code that we don't want to show.

### Notes for Testing:
run `mypy .`