### PR TITLE
feat: catch rasterio warnings to log

### DIFF
--- a/topo_processor/metadata/metadata_loaders/metadata_loader_tiff.py
+++ b/topo_processor/metadata/metadata_loaders/metadata_loader_tiff.py
@@ -30,7 +30,7 @@ class MetadataLoaderTiff(MetadataLoader):
             fs = get_fs(asset.source_path)
             # FIXME: Should we download the file first as we could need it to do the coggification later?
             # This process takes quiet a long time locally.
-            
+
             with fs.open(asset.source_path) as f:
                 with warnings.catch_warnings(record=True) as w:
                     with rasterio.open(f) as tiff:

--- a/topo_processor/metadata/metadata_loaders/metadata_loader_tiff.py
+++ b/topo_processor/metadata/metadata_loaders/metadata_loader_tiff.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING, Any, Optional
 
 import rasterio
+from linz_logger import get_log
 from rasterio.enums import ColorInterp
 
 from topo_processor.file_system.get_fs import get_fs
@@ -28,10 +30,14 @@ class MetadataLoaderTiff(MetadataLoader):
             fs = get_fs(asset.source_path)
             # FIXME: Should we download the file first as we could need it to do the coggification later?
             # This process takes quiet a long time locally.
+            
             with fs.open(asset.source_path) as f:
-                with rasterio.open(f) as tiff:
-                    self.add_epsg(tiff, asset)
-                    self.add_bands(tiff, asset)
+                with warnings.catch_warnings(record=True) as w:
+                    with rasterio.open(f) as tiff:
+                        self.add_epsg(tiff, asset)
+                        self.add_bands(tiff, asset)
+                for warn in w:
+                    get_log().warning(f"Rasterio Warning: {warn.message}", file=asset.source_path, loader=self.name)
 
     def add_epsg(self, tiff: Any, asset: Asset) -> None:
         if tiff.crs:


### PR DESCRIPTION
Currently rasterio provides the warning message:
```/usr/local/lib/python3.8/dist-packages/rasterio/io.py:131: NotGeoreferencedWarning: Dataset has no geotransform, gcps, or rpcs. The identity matrix be returned.```

This is ok as we are not expecting historical imagery to be georeferenced but have decided to 'catch' the warning to log them in a similar fashion to other topo-processor logs and to associate the warning with the tiff file it relates to.