### PR TITLE
fix: allow for unicode character in metadata csv

### DIFF
--- a/topo_processor/metadata/metadata_loaders/metadata_loader_imagery_historic.py
+++ b/topo_processor/metadata/metadata_loaders/metadata_loader_imagery_historic.py
@@ -156,6 +156,8 @@ class MetadataLoaderImageryHistoric(MetadataLoader):
 
     def add_spatial_extent(self, item: Item, asset_metadata: Dict[str, str]) -> None:
         wkt = asset_metadata.get("WKT", None)
+        if wkt is None:
+            wkt = asset_metadata.get("\ufeffWKT", None)
         if wkt is None or wkt.lower() == "polygon empty":
             item.add_warning("Geometry is missing", "")
             return

--- a/topo_processor/metadata/metadata_loaders/metadata_loader_imagery_historic.py
+++ b/topo_processor/metadata/metadata_loaders/metadata_loader_imagery_historic.py
@@ -156,8 +156,6 @@ class MetadataLoaderImageryHistoric(MetadataLoader):
 
     def add_spatial_extent(self, item: Item, asset_metadata: Dict[str, str]) -> None:
         wkt = asset_metadata.get("WKT", None)
-        if wkt is None:
-            wkt = asset_metadata.get("\ufeffWKT", None)
         if wkt is None or wkt.lower() == "polygon empty":
             item.add_warning("Geometry is missing", "")
             return

--- a/topo_processor/util/gzip.py
+++ b/topo_processor/util/gzip.py
@@ -15,7 +15,7 @@ def decompress_file(file_path: str) -> None:
 
     try:
         input = gzip.GzipFile(file_path, "rb")
-        s = input.read()
+        s = input.read().decode("utf-8-sig")
     except gzip.BadGzipFile as e:
         get_log().error("File decompression failed", file=file_path, error=e)
         raise e
@@ -23,6 +23,6 @@ def decompress_file(file_path: str) -> None:
         if input:
             input.close()
 
-    output = open(file_path, "wb")
+    output = open(file_path, "w")
     output.write(s)
     output.close()


### PR DESCRIPTION
When using the lds cache metadata the code was completing but with null geometries:
```json
{
    "error": [
        {
            "msg": "Geometry is missing",
            "level": "warning",
            "cause": "",
            "error": null
        }
    ],
    "level": 40,
    "time": 1643744247646,
    "v": 1,
    "pid": 1,
    "msg": "Item 36925 contains warnings:"
}
```
This was due to the WKT csv name being `\\ufeffWKT`