### PR TITLE
feat: use stac encoding field 

### DIFF
--- a/topo_processor/stac/lds_cache.py
+++ b/topo_processor/stac/lds_cache.py
@@ -4,43 +4,43 @@ import pystac
 
 from topo_processor.util.aws_files import build_s3_path, load_file_content, s3_download
 from topo_processor.util.configuration import lds_cache_bucket, temp_folder
-from topo_processor.util.gzip import decompress_file, is_gzip_file
+from topo_processor.util.gzip import decompress_file
+
+
+def get_latest_item_path(collection: pystac.Collection) -> pystac.Link:
+    for link in reversed(collection.get_links()):
+        if not link.rel == "item":
+            continue
+        return link
+
+    raise Exception(f"No version found for Collection {collection.title}")
+
+
+def get_latest_item(layer: str) -> pystac.Item:
+    collection = pystac.Collection.from_dict(load_file_content(lds_cache_bucket, layer + "/collection.json"))
+
+    latest_item = get_latest_item_path(collection)
+    latest_item_path = f"{layer}/{latest_item.href.lstrip('./')}"
+    return pystac.Item.from_dict(load_file_content(lds_cache_bucket, latest_item_path))
 
 
 def get_layer(layer: str) -> str:
-    """Download and return local path to the metadata file for the layer. If no version specified, get the latest version"""
+    """Download and return local path to the metadata file for the layer"""
 
-    collection: pystac.Collection = get_collection(layer)
-    version_number = get_last_version(collection)
+    latest_item = get_latest_item(layer)
 
-    metadata_file_name = get_metadata_file_name(layer, version_number)
-    metadata_file_path = temp_folder + "/" + metadata_file_name
-    s3_download(build_s3_path(lds_cache_bucket, layer + "/" + metadata_file_name), metadata_file_path)
+    exported_asset = latest_item.assets.get("export", None)
+    if exported_asset is None:
+        raise Exception(f"No exported asset found for lds layer: {layer}")
+
+    asset_path = exported_asset.href.lstrip("./")
+
+    metadata_file_path = f"{temp_folder}/{asset_path}"
+    s3_download(build_s3_path(lds_cache_bucket, f"{layer}/{asset_path}"), metadata_file_path)
 
     if os.path.isfile(metadata_file_path):
-        if is_gzip_file(metadata_file_path):
+        if exported_asset.extra_fields.get("encoding", None) == "gzip":
             decompress_file(metadata_file_path)
         return metadata_file_path
     else:
         raise Exception(f"{metadata_file_path} not found")
-
-
-def get_collection(layer: str) -> pystac.Collection:
-    return pystac.Collection.from_dict(load_file_content(lds_cache_bucket, layer + "/collection.json"))
-
-
-def get_last_version(collection: pystac.Collection) -> str:
-    # Get the last link item
-    href = collection.get_links()[-1].get_href()
-
-    if not href or not href.endswith(".json"):
-        raise Exception(f"No version found for Collection {collection.title}")
-
-    item_file_name: str = os.path.basename(href)
-    version = item_file_name.replace(".json", "").split("_", 1)[1]
-
-    return version
-
-
-def get_metadata_file_name(layer: str, version: str) -> str:
-    return layer + "_" + version + ".csv"

--- a/topo_processor/stac/tests/lds_cache_test.py
+++ b/topo_processor/stac/tests/lds_cache_test.py
@@ -16,8 +16,4 @@ def test_get_last_version() -> None:
     link_d: pystac.Link = pystac.Link(rel=pystac.RelType.ITEM, target="./1234_100001.json")
     collection.add_links([link_a, link_b, link_c, link_d])
 
-    assert lds_cache.get_last_version(collection) == "100001"
-
-
-def test_get_metadata_file_path() -> None:
-    assert lds_cache.get_metadata_file_name("12345", "123456") == "12345_123456.csv"
+    assert lds_cache.get_latest_item_path(collection).target == "./1234_100001.json"


### PR DESCRIPTION
Not all assets should be decompressed automatically, only decompress the ones that have a `ContentEncoding` set

this also changes the behaviour to look for the last "rel: item" in the collection links  rather than just the last record in the list as not everything in that list is a "rel: item"