### PR TITLE
fix: change logs for filter_metadata and avoid looping over all metadata records while upload with survey ID (TDE-326)

### DIFF
--- a/topo_processor/file_system/file_searcher.py
+++ b/topo_processor/file_system/file_searcher.py
@@ -12,7 +12,7 @@ from topo_processor.util.configuration import historical_imagery_bucket
 def get_file_path_from_survey(survey_id: str, manifest_path: str, metadata_path: str = "") -> List[str]:
     list_file_path: List[str] = []
     criteria = {"survey": survey_id}
-    metadata = get_metadata(DataType.IMAGERY_HISTORIC, criteria, metadata_path)
+    metadata = get_metadata(DataType.IMAGERY_HISTORIC, criteria, metadata_path, True)
     manifest = load_manifest(manifest_path)
 
     for metadata_row in metadata.values():


### PR DESCRIPTION
- A logging has been removed as it is not really useful to know if a key exists or not.
- The metadata filtered by survey id is now saved (when `upload` is called with a survey id - not a path) which improve performances as the next search for items in the metadata is done on the filtered records and not the full list of records.