### PR TITLE
perf: do not use rasterio to check tiff band validity TDE-333

### DIFF
--- a/topo_processor/metadata/metadata_validators/metadata_validator_tiff.py
+++ b/topo_processor/metadata/metadata_validators/metadata_validator_tiff.py
@@ -58,4 +58,4 @@ class MetadataValidatorTiff(MetadataValidator):
                 else:
                     raise Exception(f"Unknown linz_geospatial_type of '{geospatial_type}'")
         for warn in w:
-                    get_log().warning(f"Warning: {warn.message}", file=asset.source_path, loader=self.name)
+            get_log().warning(f"Warning: {warn.message}", file=asset.source_path, loader=self.name)

--- a/topo_processor/metadata/metadata_validators/metadata_validator_tiff.py
+++ b/topo_processor/metadata/metadata_validators/metadata_validator_tiff.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 import warnings
 from typing import TYPE_CHECKING
 
-import rasterio
 from linz_logger import get_log
-from rasterio.enums import ColorInterp
 
 from topo_processor.file_system.get_fs import get_fs
 from topo_processor.util.file_extension import is_tiff
@@ -27,44 +25,37 @@ class MetadataValidatorTiff(MetadataValidator):
 
     def validate_metadata(self, item: Item) -> None:
 
-        geospatial_type = item.linz_geospatial_type
         for asset in item.assets:
             if not is_tiff(asset.source_path):
                 continue
+
+            geospatial_type = item.linz_geospatial_type
             eo_bands = asset.properties["eo:bands"]
-            fs = get_fs(asset.source_path)
-            with fs.open(asset.source_path) as f:
-                with warnings.catch_warnings(record=True) as w:
-                    with rasterio.open(f) as tiff:
-                        # black and white
-                        if ColorInterp.gray in tiff.colorinterp and len(tiff.colorinterp) == 1:
-                            # check linz_geospatial_type matches colorinterp
-                            if geospatial_type not in ["black and white image", "black and white infrared image"]:
-                                raise Exception(
-                                    f"Wrong linz_geospatial_type of '{geospatial_type}' when bands = {', '.join([color.name for color in tiff.colorinterp])}"
-                                )
-                            # check eo:bands matches colorinterp
-                            if len(eo_bands) != 1 or eo_bands[0]["common_name"] != "pan":
-                                raise Exception(
-                                    f"Wrong 'eo:bands' with common name: '{geospatial_type}' when bands = {', '.join([color.name for color in tiff.colorinterp])}"
-                                )
-                        # color
-                        if all(band in [ColorInterp.red, ColorInterp.blue, ColorInterp.green] for band in tiff.colorinterp):
-                            common_names = [common_names["common_name"] for common_names in eo_bands]
-                            # check linz_geospatial_type matches colorinterp
-                            if geospatial_type not in ["color image", "color infrared image"]:
-                                raise Exception(
-                                    f"Wrong linz_geospatial_type of '{geospatial_type}' when bands = {', '.join([color.name for color in tiff.colorinterp])}"
-                                )
-                            # check eo:bands matches colorinterp
-                            if (
-                                len(eo_bands) != 3
-                                or "red" not in common_names
-                                or "green" not in common_names
-                                or "blue" not in common_names
-                            ):
-                                raise Exception(
-                                    f"Wrong 'eo:bands' with common name: {geospatial_type} when bands = {', '.join([color.name for color in tiff.colorinterp])}"
-                                )
-                for warn in w:
-                    get_log().warning(f"Rasterio Warning: {warn.message}", file=asset.source_path, loader=self.name)
+
+            with warnings.catch_warnings(record=True) as w:
+
+                # black and white
+                if geospatial_type in ["black and white image", "black and white infrared image"]:
+                    # check eo:bands matches geospatial_type
+                    if len(eo_bands) != 1 or eo_bands[0]["common_name"] != "pan":
+                        raise Exception(f"Wrong linz_geospatial_type of '{geospatial_type}' when bands = '{eo_bands}'")
+                    else:
+                        continue
+                # color
+                common_names = [common_names["common_name"] for common_names in eo_bands]
+                # check linz_geospatial_type matches colorinterp
+                if geospatial_type in ["color image", "color infrared image"]:
+                    # check eo:bands matches colorinterp
+                    if (
+                        len(eo_bands) != 3
+                        or "red" not in common_names
+                        or "green" not in common_names
+                        or "blue" not in common_names
+                    ):
+                        raise Exception(f"Wrong linz_geospatial_type of '{geospatial_type}' when bands = '{eo_bands}'")
+                    else:
+                        continue
+                else:
+                    raise Exception(f"Unknown linz_geospatial_type of '{geospatial_type}'")
+        for warn in w:
+                    get_log().warning(f"Warning: {warn.message}", file=asset.source_path, loader=self.name)

--- a/topo_processor/metadata/metadata_validators/metadata_validator_tiff.py
+++ b/topo_processor/metadata/metadata_validators/metadata_validator_tiff.py
@@ -31,6 +31,7 @@ class MetadataValidatorTiff(MetadataValidator):
 
             geospatial_type = item.linz_geospatial_type
             eo_bands = asset.properties["eo:bands"]
+            common_names = [common_names["common_name"] for common_names in eo_bands]
 
             with warnings.catch_warnings(record=True) as w:
 
@@ -40,9 +41,8 @@ class MetadataValidatorTiff(MetadataValidator):
                     if len(eo_bands) != 1 or eo_bands[0]["common_name"] != "pan":
                         raise Exception(f"Wrong linz_geospatial_type of '{geospatial_type}' when bands = '{eo_bands}'")
                 # color
-                common_names = [common_names["common_name"] for common_names in eo_bands]
                 # check linz_geospatial_type matches colorinterp
-                if geospatial_type in ["color image", "color infrared image"]:
+                elif geospatial_type in ["color image", "color infrared image"]:
                     # check eo:bands matches colorinterp
                     if (
                         len(eo_bands) != 3

--- a/topo_processor/metadata/metadata_validators/metadata_validator_tiff.py
+++ b/topo_processor/metadata/metadata_validators/metadata_validator_tiff.py
@@ -39,8 +39,6 @@ class MetadataValidatorTiff(MetadataValidator):
                     # check eo:bands matches geospatial_type
                     if len(eo_bands) != 1 or eo_bands[0]["common_name"] != "pan":
                         raise Exception(f"Wrong linz_geospatial_type of '{geospatial_type}' when bands = '{eo_bands}'")
-                    else:
-                        continue
                 # color
                 common_names = [common_names["common_name"] for common_names in eo_bands]
                 # check linz_geospatial_type matches colorinterp
@@ -53,8 +51,6 @@ class MetadataValidatorTiff(MetadataValidator):
                         or "blue" not in common_names
                     ):
                         raise Exception(f"Wrong linz_geospatial_type of '{geospatial_type}' when bands = '{eo_bands}'")
-                    else:
-                        continue
                 else:
                     raise Exception(f"Unknown linz_geospatial_type of '{geospatial_type}'")
         for warn in w:

--- a/topo_processor/metadata/metadata_validators/tests/metadata_validator_tiff_test.py
+++ b/topo_processor/metadata/metadata_validators/tests/metadata_validator_tiff_test.py
@@ -17,5 +17,21 @@ def test_check_validity() -> None:
 
     validator = MetadataValidatorTiff()
     assert validator.is_applicable(item)
-    with pytest.raises(Exception, match=r"Wrong linz_geospatial_type of 'color image' when bands = gray"):
+    with pytest.raises(
+        Exception, match=r"Wrong linz_geospatial_type of 'color image' when bands = [{'name': 'gray', 'common_name': 'pan'}]"
+    ):
+        validator.validate_metadata(item)
+
+
+def test_unknown_geospatial_type() -> None:
+    source_path = os.path.join(os.getcwd(), "test_data", "tiffs", "SURVEY_1", "CONTROL.tiff")
+    asset = Asset(source_path)
+    item = Item("item_id")
+    item.add_asset(asset)
+    item.linz_geospatial_type = "grayscale"
+    asset.properties.update({"eo:bands": [{"name": "gray", "common_name": "pan"}]})
+
+    validator = MetadataValidatorTiff()
+    assert validator.is_applicable(item)
+    with pytest.raises(Exception, match=r"Unknown linz_geospatial_type of 'grayscale'"):
         validator.validate_metadata(item)


### PR DESCRIPTION
Rasterio was used to get the band information from the TIFF and also to get it again for checking the metadata.
This PR is to remove Rasterio from the second check, using the values originally got from the TIFF.