### PR TITLE
feat(cdk): lambda function to monitor batch job failures

### DIFF
--- a/.github/workflows/build.ts.yml
+++ b/.github/workflows/build.ts.yml
@@ -44,7 +44,7 @@ jobs:
       - name: (NonProd) Deploy to NonProd
         if: github.ref == 'refs/heads/master'
         run: |
-          npx cdk deploy -y --require-approval never
+          npx cdk deploy --all -y --require-approval never
         env:
           AWS_ORG_ID: ${{secrets.AWS_ORG_ID}}
 
@@ -58,6 +58,6 @@ jobs:
       - name: (Prod) Deploy to Prod
         if: github.ref == 'refs/heads/master' && startsWith(github.event.head_commit.message, 'release:')
         run: |
-          npx cdk deploy -y --require-approval never
+          npx cdk deploy --all -y --require-approval never
         env:
           AWS_ORG_ID: ${{secrets.AWS_ORG_ID}}

--- a/infra/src/batch-monitor.ts
+++ b/infra/src/batch-monitor.ts
@@ -1,0 +1,29 @@
+import { Stack, StackProps } from 'aws-cdk-lib';
+import * as events from 'aws-cdk-lib/aws-events';
+import * as evtTargets from 'aws-cdk-lib/aws-events-targets';
+import * as lf from 'aws-cdk-lib/aws-lambda';
+import { Code } from 'aws-cdk-lib/aws-lambda';
+import { Construct } from 'constructs';
+import * as path from 'path';
+
+export class AwsBatchMonitor extends Stack {
+  public constructor(scope: Construct, id: string, props: StackProps) {
+    super(scope, id, props);
+
+    const rule = new events.Rule(this, 'BatchEventRule', {
+      eventPattern: {
+        source: ['aws.batch'],
+        detailType: ['Batch Job State Change'],
+        detail: { status: ['FAILED'] },
+      },
+    });
+
+    const lambda = new lf.Function(this, 'BatchLog', {
+      runtime: lf.Runtime.NODEJS_14_X,
+      handler: 'index.handler',
+      code: Code.fromAsset(path.join(process.cwd(), 'infra', 'src', 'lambda-code', 'index.js')),
+    });
+
+    rule.addTarget(new evtTargets.LambdaFunction(lambda));
+  }
+}

--- a/infra/src/batch-monitor.ts
+++ b/infra/src/batch-monitor.ts
@@ -14,14 +14,13 @@ export class AwsBatchMonitor extends Stack {
       eventPattern: {
         source: ['aws.batch'],
         detailType: ['Batch Job State Change'],
-        detail: { status: ['FAILED'] },
       },
     });
 
     const lambda = new lf.Function(this, 'BatchLog', {
       runtime: lf.Runtime.NODEJS_14_X,
       handler: 'index.handler',
-      code: Code.fromAsset(path.join(process.cwd(), 'infra', 'src', 'lambda-code', 'index.js')),
+      code: Code.fromAsset(path.join(process.cwd(), 'infra', 'src', 'lambda-code')),
     });
 
     rule.addTarget(new evtTargets.LambdaFunction(lambda));

--- a/infra/src/index.ts
+++ b/infra/src/index.ts
@@ -1,5 +1,6 @@
 import { App } from 'aws-cdk-lib';
 import { AwsBatchStack } from './batch';
+import { AwsBatchMonitor } from './batch-monitor';
 
 const app = new App();
 new AwsBatchStack(app, 'TopoProcessorBatch', {
@@ -8,4 +9,10 @@ new AwsBatchStack(app, 'TopoProcessorBatch', {
     account: process.env['CDK_DEFAULT_ACCOUNT'],
   },
   container: './',
+});
+new AwsBatchMonitor(app, 'TopoProcessorBatchMon', {
+  env: {
+    region: 'ap-southeast-2',
+    account: process.env['CDK_DEFAULT_ACCOUNT'],
+  },
 });

--- a/infra/src/lambda-code/index.js
+++ b/infra/src/lambda-code/index.js
@@ -1,0 +1,5 @@
+function handler(event, ctx, cb) {
+  console.log(JSON.stringify({ event }));
+  cb(null, 'done');
+}
+module.exports = { handler };


### PR DESCRIPTION
Creates a lambda function to log to elastic search events in `li-topo-prod` and `li-topo-nonprod` that follow the pattern:
```
source: ['aws.batch'],
detailType: ['Batch Job State Change'],
detail: { status: ['FAILED'] },
```

**nb: I added `--all` to the nonprod and prod deployment workflows in `.github/workflows/build.ts.yml` this means it should deploy both `TopoProcessorBatch` and `TopoProcessorMon` on merge to master for nonprod and on publish for prod.** - Is this ok?