### PR TITLE
release: 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+<a name="0.6.0"></a>
+# [0.6.0](https://github.com/linz/topo-processor/compare/v0.5.0...v0.6.0) (2022-05-26)
+
+
+
 <a name="0.5.0"></a>
 # [0.5.0](https://github.com/linz/topo-processor/compare/v0.3.0...v0.5.0) (2022-05-26)
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "aws-cdk": "2.25.0",
     "conventional-github-releaser": "^3.1.5"
   },
-  "version": "0.5.0",
+  "version": "0.6.0",
   "scripts": {
     "build": "tsc",
     "version": "conventional-changelog -p angular -i CHANGELOG.md -s && git add CHANGELOG.md",


### PR DESCRIPTION
Testing to see if the error was a transient error, as it passed the test when the previous PR was merged.