### PR TITLE
fix: provision user in aws infrastructure repo

### DIFF
--- a/infra/src/batch.ts
+++ b/infra/src/batch.ts
@@ -7,7 +7,6 @@ import {
   ServicePrincipal,
   CfnInstanceProfile,
   ManagedPolicy,
-  OrganizationPrincipal,
   PolicyStatement,
 } from 'aws-cdk-lib/aws-iam';
 import { Vpc, InstanceClass, InstanceType, InstanceSize } from 'aws-cdk-lib/aws-ec2';

--- a/infra/src/batch.ts
+++ b/infra/src/batch.ts
@@ -48,7 +48,7 @@ export class AwsBatchStack extends Stack {
       lifecycleRules: [{ expiration: Duration.days(30) }],
     });
 
-    const roRole = Role.fromRoleName(this, 'internal-user-read', 'internal-user-read');
+    const roRole = Role.fromRoleName(this, 'LINZReadRole', 'internal-user-read');
     tempBucket.grantRead(roRole);
     tempBucket.grantReadWrite(instanceRole);
     StringParameter.fromStringParameterName(this, 'BucketConfig', 'BucketConfig').grantRead(instanceRole);

--- a/infra/src/batch.ts
+++ b/infra/src/batch.ts
@@ -48,15 +48,9 @@ export class AwsBatchStack extends Stack {
       blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
       lifecycleRules: [{ expiration: Duration.days(30) }],
     });
-    if (process.env.AWS_ORG_ID) {
-      const principal = new OrganizationPrincipal(process.env.AWS_ORG_ID);
-      const roRole = new Role(this, 'LINZReadRole', {
-        roleName: 'internal-user-read',
-        assumedBy: principal,
-      });
-      tempBucket.grantRead(roRole);
-      new CfnOutput(this, 'LINZRoleReadArn', { value: roRole.roleArn });
-    }
+
+    const roRole = Role.fromRoleName(this, 'internal-user-read', 'internal-user-read');
+    tempBucket.grantRead(roRole);
     tempBucket.grantReadWrite(instanceRole);
     StringParameter.fromStringParameterName(this, 'BucketConfig', 'BucketConfig').grantRead(instanceRole);
 


### PR DESCRIPTION
This PR goes with [https://github.com/linz/topo-aws-infrastructure/pull/44](https://github.com/linz/topo-aws-infrastructure/pull/44) to manage the users in the topo-aws-infrastructure code instead of in the Topo Processor code.