### PR TITLE
fix: TDE-383 commit VERSION and pyproject.toml files

### DIFF
--- a/scripts/version.bump.sh
+++ b/scripts/version.bump.sh
@@ -19,6 +19,9 @@ poetry version ${CURRENT_VERSION}
 # Write version to a file for Topo Processor to use
 echo v${CURRENT_VERSION} | tee VERSION
 
+# Commit the changed files
+git commit -a --amend --no-edit
+
 # Checkout a new release branch
 git checkout -b release/v${CURRENT_VERSION}
 


### PR DESCRIPTION
When a new release is made, the git tag, package.json, pyproject.toml and VERSION files are updated with the new version number.
The pyproject.toml and VERSION files are never committed so do not get updated with the release.
This fix is to commit all the changes.