### PR TITLE
fix: TDE-392 stop processing when an image transform fails

### DIFF
--- a/topo_processor/cog/execution.py
+++ b/topo_processor/cog/execution.py
@@ -18,7 +18,7 @@ class ExecutionLocal:
 
         proc = subprocess.run(cmd.to_full_command(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         if proc.returncode != 0:
-            get_log().trace("Ran command failed", command=cmd.redacted_command(), duration=time_in_ms() - start_time)
+            get_log().error("Ran command failed", command=cmd.redacted_command(), duration=time_in_ms() - start_time)
             raise Exception(proc.stderr.decode())
         get_log().trace("Ran command succeeded", command=cmd.redacted_command(), duration=time_in_ms() - start_time)
         return proc.returncode, proc.stdout.decode(), proc.stderr.decode()

--- a/topo_processor/data/data_transformers/data_transformer_imagery_historic.py
+++ b/topo_processor/data/data_transformers/data_transformer_imagery_historic.py
@@ -38,7 +38,12 @@ class DataTransformerImageryHistoric(DataTransformer):
                 return
             output_path = os.path.join(item.collection.get_temp_dir(), f"{ulid.ULID()}.tiff")
 
-            create_cog(asset.source_path, output_path).run()
+            try:
+                test = create_cog(asset.source_path, output_path).run()
+            except Exception as e:
+                raise Exception(
+                    f"COG creation failed for item {item.id} with source path {asset.source_path} and output path {output_path}. Process is stopped."
+                ) from e
 
             get_log().debug("Created COG", output_path=output_path, duration=time_in_ms() - start_time)
 

--- a/topo_processor/data/data_transformers/data_transformer_repo.py
+++ b/topo_processor/data/data_transformers/data_transformer_repo.py
@@ -26,8 +26,8 @@ class DataTransformerRepository:
                     transformer.transform_data(item)
                 except Exception as e:
                     item.add_error(str(e), transformer.name, e)
-                    get_log().warning(f"Data Transform Failed: {e}", transformers=transformer.name)
-                    return
+                    get_log().error(f"Data Transform Failed: {e}", transformers=transformer.name)
+                    raise Exception("Data Transform Failed")
                 get_log().debug(
                     "Data Transformed",
                     duration=time_in_ms() - start_time,

--- a/topo_processor/metadata/lds_cache/lds_cache.py
+++ b/topo_processor/metadata/lds_cache/lds_cache.py
@@ -86,5 +86,4 @@ def filter_metadata(metadata_to_filter: Dict[str, Any], criteria: Dict[str, Any]
                     break
         if is_found:
             filtered_dict[metadata_key] = metadata_value
-    get_log().debug("filter_metadata_end", metadata=filtered_dict)
     return filtered_dict

--- a/topo_processor/metadata/lds_cache/lds_cache.py
+++ b/topo_processor/metadata/lds_cache/lds_cache.py
@@ -72,7 +72,7 @@ def get_metadata(
 
 
 def filter_metadata(metadata_to_filter: Dict[str, Any], criteria: Dict[str, Any]) -> Dict[str, Any]:
-    get_log().debug("filter_metadata_start", criteria=criteria)
+    get_log().debug("filter_metadata", criteria=criteria)
     filtered_dict: Dict[str, Any] = {}
     is_found = False
 


### PR DESCRIPTION
This also removes a noisy logging line in the LDS cache code that was polluting our ElasticSearch logging.