### PR TITLE
fix: TDE-404 geostore CLI logging changes and revert list data type search

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,11 +165,10 @@ This is to follow the current upload status to the `Geostore` for a particular `
 
 It gives you the information for one or all the datasets created on the `Geostore`.
 
-| Argument                |                                         Description                                          |
-| ----------------------- | :------------------------------------------------------------------------------------------: |
-| `-s`, `--survey` TEXT   |                                     The survey to filter                                     |
-| `-d`, `--datatype` TEXT | The datatype of the upload. _Only `imagery.historic` is available at the moment._ [required] |
-| `-v`, `--verbose`       |                              Use verbose to display debug logs                               |
+| Argument             |                                      Description                                      |
+| -------------------- | :-----------------------------------------------------------------------------------: |
+| `-t`, `--title` TEXT | The Geostore title of the survey to filter e.g. historical-aerial-imagery-survey-2660 |
+| `-v`, `--verbose`    |                           Use verbose to display debug logs                           |
 
 ```bash
 poetry run list [-s ID123ABC]

--- a/topo_processor/cli/geostore/add.py
+++ b/topo_processor/cli/geostore/add.py
@@ -122,14 +122,18 @@ def main(source: str, role: str, commit: bool, verbose: bool) -> None:
             # Check import status
             import_status = invoke_import_status(execution_arn)
 
+            logger.info(
+                "geostore_add_invoked",
+                info=f"To check the import status, run the following command 'poetry run status -a {execution_arn}'",
+            )
+
             logger.debug(
-                "geostore_add_completed",
+                "geostore_add_details",
                 source=source,
                 datasetId=dataset_id,
                 executionArn=execution_arn,
                 currentImportStatus=import_status,
                 duration=time_in_ms() - start_time,
-                info=f"To check the export status, run the following command 'poetry run status -a {execution_arn}'",
             )
         else:
             source_parse = urlparse(source, allow_fragments=False)

--- a/topo_processor/cli/geostore/list.py
+++ b/topo_processor/cli/geostore/list.py
@@ -8,7 +8,7 @@ from topo_processor.util.time import time_in_ms
 @click.command()
 @click.option(
     "-s",
-    "--survey",
+    "--title",
     required=False,
     help="The Geostore title of the survey to filter",
 )
@@ -18,18 +18,18 @@ from topo_processor.util.time import time_in_ms
     is_flag=True,
     help="Use verbose to display debug logs",
 )
-def main(survey: str, verbose: bool) -> None:
+def main(title: str, verbose: bool) -> None:
     start_time = time_in_ms()
     logger = get_log()
-    logger.info("list_datasets_start", survey=survey)
+    logger.info("list_datasets_start", title=title)
 
     if not verbose:
         set_level(LogLevel.info)
 
     try:
         list_parameters = {}
-        if survey:
-            list_parameters = {"title": survey}
+        if title:
+            list_parameters = {"title": title}
         dataset_list = invoke_lambda("datasets", "GET", list_parameters)
 
         logger.info("list_datasets_end", dataset_list=dataset_list, duration=time_in_ms() - start_time)

--- a/topo_processor/cli/geostore/list.py
+++ b/topo_processor/cli/geostore/list.py
@@ -2,7 +2,6 @@ import click
 from linz_logger import LogLevel, get_log, set_level
 
 from topo_processor.geostore.invoke import invoke_lambda
-from topo_processor.metadata.data_type import DataType
 from topo_processor.util.time import time_in_ms
 
 
@@ -11,14 +10,7 @@ from topo_processor.util.time import time_in_ms
     "-s",
     "--survey",
     required=False,
-    help="The survey to filter",
-)
-@click.option(
-    "-d",
-    "--datatype",
-    required=True,
-    type=click.Choice([data_type for data_type in DataType], case_sensitive=True),
-    help="The datatype of the upload",
+    help="The Geostore title of the survey to filter",
 )
 @click.option(
     "-v",
@@ -26,24 +18,18 @@ from topo_processor.util.time import time_in_ms
     is_flag=True,
     help="Use verbose to display debug logs",
 )
-def main(survey: str, datatype: str, verbose: bool) -> None:
+def main(survey: str, verbose: bool) -> None:
     start_time = time_in_ms()
-    data_type = DataType(datatype)
     logger = get_log()
     logger.info("list_datasets_start", survey=survey)
 
     if not verbose:
         set_level(LogLevel.info)
 
-    if data_type == DataType.IMAGERY_HISTORIC:
-        title_prefix = "historical-aerial-imagery-survey-"
-    else:
-        raise Exception("Data type not yet implemented")
-
     try:
         list_parameters = {}
         if survey:
-            list_parameters = {"title": title_prefix + survey}
+            list_parameters = {"title": survey}
         dataset_list = invoke_lambda("datasets", "GET", list_parameters)
 
         logger.info("list_datasets_end", dataset_list=dataset_list, duration=time_in_ms() - start_time)

--- a/topo_processor/cli/geostore/list.py
+++ b/topo_processor/cli/geostore/list.py
@@ -7,7 +7,7 @@ from topo_processor.util.time import time_in_ms
 
 @click.command()
 @click.option(
-    "-s",
+    "-t",
     "--title",
     required=False,
     help="The Geostore title of the survey to filter",

--- a/topo_processor/cli/geostore/status.py
+++ b/topo_processor/cli/geostore/status.py
@@ -21,7 +21,7 @@ from topo_processor.util.time import time_in_ms
 def main(execution_arn: str, verbose: bool) -> None:
     start_time = time_in_ms()
     logger = get_log()
-    logger.info("check_export_status_start", arn=execution_arn)
+    logger.info("check_import_status_start", arn=execution_arn)
 
     if not verbose:
         set_level(LogLevel.info)
@@ -29,10 +29,15 @@ def main(execution_arn: str, verbose: bool) -> None:
     try:
         import_status = invoke_import_status(execution_arn)
 
+        logger.info(
+            "check_import_status",
+            current_import_status=import_status,
+        )
+
         logger.debug(
             "check_export_status_end",
-            current_export_status=import_status,
             duration=time_in_ms() - start_time,
         )
+
     except Exception as e:
-        logger.error("check_export_status_failed", err=e)
+        logger.error("check_import_status_failed", err=e)


### PR DESCRIPTION
This also reverses the previous change to listing by `survey` and `datatype` as it was better in some ways but worse in others (couldn't list all datasets).